### PR TITLE
Remove legacy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,4 +51,4 @@ jobs:
         cd onnx-connx
         cp ../build/connx ./onnx_connx/connx
         pip3 install -U onnx protobuf tabulate pytest
-        pytest
+        pytest -v

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Clone onnx-connx
       uses: actions/checkout@master
       with:
-        repository: semihlab/onnx-connx
+        repository: tsnlab/onnx-connx
         path: onnx-connx
     - name: ONNX Test Cases
       run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Welcome to CONNX project and very welcome your contirbutions.
  2. Convert ONNX test case to CONNX using [onnx-connx][]'s bin/convert utility
  3. ports/linux$ ninja -C build onnx
 
-[onnx-connx]: https://github.com/semihlab/onnx-connx
+[onnx-connx]: https://github.com/tsnlab/onnx-connx
 
 # How to contribute code
  1. Pass all the onnx test cases

--- a/bin/gen.sh
+++ b/bin/gen.sh
@@ -88,6 +88,7 @@ done
 
 if [[ ${IS_DUMP} == 0 ]]; then
     mkdir -p ${OUTPUT_DIR}/opset
+    mkdir -p ${OUTPUT_DIR}/templates
 fi
 
 # Copy connx codes
@@ -131,6 +132,15 @@ else
         $HOME/ver.sh > ${OUTPUT_DIR}/ver.h
     fi
 fi
+
+# Generate template jinja first
+for FILE in ${INPUT_DIR}/opset/__*.jinja.c; do
+    fname=$(basename ${FILE})
+    if [[ ${FILE} -nt ${OUTPUT_DIR}/templates/${fname} ]]; then
+        echo "Generating ${OUTPUT_DIR}/templates/${fname}"
+        TEMPLATE=1 ${HOME}/preprocessor.py ${FILE} ${OUTPUT_DIR}/templates/${fname}
+    fi
+done
 
 # Generate opset codes
 for FILE in ${OPSET}; do

--- a/bin/gen.sh
+++ b/bin/gen.sh
@@ -136,9 +136,15 @@ fi
 # Generate template jinja first
 for FILE in ${INPUT_DIR}/opset/__*.jinja.c; do
     fname=$(basename ${FILE})
-    if [[ ${FILE} -nt ${OUTPUT_DIR}/templates/${fname} ]]; then
-        echo "Generating ${OUTPUT_DIR}/templates/${fname}"
-        TEMPLATE=1 ${HOME}/preprocessor.py ${FILE} ${OUTPUT_DIR}/templates/${fname}
+    if [[ ${IS_DUMP} == 1 ]]; then
+        # Do not echo. This is for generating template jinja
+        continue
+    else
+        if [[ ${FILE} -nt ${OUTPUT_DIR}/templates/${fname} ]] || \
+            [[ ${HOME}/preprocessor.py -nt ${OUTPUT_DIR}/opset/${FILE}.c ]]; then
+            echo "Generating ${OUTPUT_DIR}/templates/${fname}"
+            TEMPLATE=1 ${HOME}/preprocessor.py ${FILE} ${OUTPUT_DIR}/templates/${fname}
+        fi
     fi
 done
 

--- a/bin/preprocessor.py
+++ b/bin/preprocessor.py
@@ -164,6 +164,13 @@ templates_dir = os.path.join(
     'templates',
 )
 
+if IS_TEMPLATE and not os.path.exists(templates_dir):
+    # Create templates directory
+    try:
+        os.makedirs(templates_dir)
+    except OSError:
+        pass
+
 jinja_env = jinja2.Environment(
     loader=jinja2.FileSystemLoader(templates_dir),
     block_start_string='/*{%',

--- a/bin/preprocessor.py
+++ b/bin/preprocessor.py
@@ -153,6 +153,7 @@ consts = {
 
 jinja2_filters = {
     'pointer': pointer,
+    'to_name': get_NAME,
 }
 
 jinja_env = jinja2.Environment(

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,7 +9,7 @@ Below command will download all the examples
 Most of models are converted from ONNX model zoo using onnx-connx tool.
 
  * ONNX model zoo: https://github.com/onnx/models
- * onnx-connx tool: https://github.com/semihlab/onnx-connx
+ * onnx-connx tool: https://github.com/tsnlab/onnx-connx
 
 # Original model license
  * MNIST - MIT

--- a/include/connx/connx.h
+++ b/include/connx/connx.h
@@ -33,8 +33,8 @@ typedef struct _connx_Model {
     connx_Graph** graphs;
 } connx_Model;
 
-typedef int (*CONNX_OPERATOR)(connx_Graph* graph, uint32_t output_count, uint32_t* outputs, uint32_t input_count, uint32_t* inputs,
-        uint32_t attribute_count, void** attributes);
+typedef int (*CONNX_OPERATOR)(connx_Graph* graph, uint32_t output_count, uint32_t* outputs, uint32_t input_count,
+                              uint32_t* inputs, uint32_t attribute_count, void** attributes);
 
 typedef struct _connx_Node {
     uint32_t output_count;

--- a/include/connx/types.h
+++ b/include/connx/types.h
@@ -75,13 +75,6 @@ typedef enum _connx_DataType {
 
 uint32_t connx_DataType_size(connx_DataType dtype);
 
-// Template engine
-#define TEMPLATE_START(...)
-#define TEMPLATE_END(...)
-#define TEMPLATE_DTYPE
-#define TEMPLATE_TYPE
-#define TEMPLATE_NAME
-
 #define UINT8 CONNX_UINT8
 #define INT8 CONNX_INT8
 #define UINT16 CONNX_UINT16

--- a/ports/esp32/main/accel.c
+++ b/ports/esp32/main/accel.c
@@ -43,41 +43,35 @@
 #define CONNX_FLOAT64_MAX DBL_MAX
 
 // Array utilities
-TEMPLATE_START(UINT8, INT8, UINT16, INT16, UINT32, INT32, UINT64, INT64, FLOAT16, FLOAT32, FLOAT64)
-#undef TEMPLATE_TYPE
-#define TEMPLATE_TYPE int32_t
-#undef TEMPLATE_NAME
-#define TEMPLATE_NAME Int32
-#define TEMPLATE_DTYPE_MAX CONNX_INT32_MAX
-#define TEMPLATE_DTYPE_MIN CONNX_INT32_MIN
+/*{% for DTYPE, TYPE in loop_types(UINT8, INT8, UINT16, INT16, UINT32, INT32, UINT64, INT64, FLOAT16, FLOAT32, FLOAT64) %}*/
 
-void connx_TEMPLATE_NAME_add(int32_t count, TEMPLATE_TYPE* c, TEMPLATE_TYPE* a, TEMPLATE_TYPE* b) {
+void connx_{{ DTYPE | to_name }}_add(int32_t count, {{TYPE}}* c, {{TYPE}}* a, {{TYPE}}* b) {
     for(int32_t i = 0; i < count; i++) {
         c[i] = a[i] + b[i];
     }
 }
 
-void connx_TEMPLATE_NAME_sub(int32_t count, TEMPLATE_TYPE* c, TEMPLATE_TYPE* a, TEMPLATE_TYPE* b) {
+void connx_{{ DTYPE | to_name }}_sub(int32_t count, {{TYPE}}* c, {{TYPE}}* a, {{TYPE}}* b) {
     for(int32_t i = 0; i < count; i++) {
         c[i] = a[i] - b[i];
     }
 }
 
-void connx_TEMPLATE_NAME_mul(int32_t count, TEMPLATE_TYPE* c, TEMPLATE_TYPE* a, TEMPLATE_TYPE* b) {
+void connx_{{ DTYPE | to_name }}_mul(int32_t count, {{TYPE}}* c, {{TYPE}}* a, {{TYPE}}* b) {
     for(int32_t i = 0; i < count; i++) {
         c[i] = a[i] * b[i];
     }
 }
 
-void connx_TEMPLATE_NAME_broadcast(int32_t y_count, TEMPLATE_TYPE* y, int32_t x_count, TEMPLATE_TYPE* x) {
+void connx_{{ DTYPE | to_name }}_broadcast(int32_t y_count, {{TYPE}}* y, int32_t x_count, {{TYPE}}* x) {
     for(int32_t i = 0; i < y_count / x_count; i++) {
-        memcpy(y + i, x, sizeof(TEMPLATE_TYPE) * x_count);
+        memcpy(y + i, x, sizeof({{TYPE}}) * x_count);
     }
 }
 
-int32_t connx_TEMPLATE_NAME_argmax(int32_t count, TEMPLATE_TYPE* y, TEMPLATE_TYPE* x) {
+int32_t connx_{{ DTYPE | to_name }}_argmax(int32_t count, {{TYPE}}* y, {{TYPE}}* x) {
     int32_t argmax = -1;
-    TEMPLATE_TYPE max = TEMPLATE_DTYPE_MIN;
+    {{TYPE}} max = {{DTYPE}}_MIN;
 
     for(int32_t i = 0; i < count; i++) {
         if(argmax == -1 || x[i] > max) {
@@ -93,9 +87,9 @@ int32_t connx_TEMPLATE_NAME_argmax(int32_t count, TEMPLATE_TYPE* y, TEMPLATE_TYP
     return argmax;
 }
 
-int32_t connx_TEMPLATE_NAME_argmin(int32_t count, TEMPLATE_TYPE* y, TEMPLATE_TYPE* x) {
+int32_t connx_{{ DTYPE | to_name }}_argmin(int32_t count, {{TYPE}}* y, {{TYPE}}* x) {
     int32_t argmin = -1;
-    TEMPLATE_TYPE min = TEMPLATE_DTYPE_MAX;
+    {{TYPE}} min = {{DTYPE}}_MAX;
 
     for(int32_t i = 0; i < count; i++) {
         if(argmin == -1 || x[i] < min) {
@@ -111,8 +105,8 @@ int32_t connx_TEMPLATE_NAME_argmin(int32_t count, TEMPLATE_TYPE* y, TEMPLATE_TYP
     return argmin;
 }
 
-TEMPLATE_TYPE connx_TEMPLATE_NAME_sum(int32_t count, TEMPLATE_TYPE* array) {
-    TEMPLATE_TYPE result = 0;
+{{TYPE}} connx_{{ DTYPE | to_name }}_sum(int32_t count, {{TYPE}}* array) {
+    {{TYPE}} result = 0;
 
     for(int32_t i = 0; i < count; i++) {
         result += array[i];
@@ -121,8 +115,8 @@ TEMPLATE_TYPE connx_TEMPLATE_NAME_sum(int32_t count, TEMPLATE_TYPE* array) {
     return result;
 }
 
-TEMPLATE_TYPE connx_TEMPLATE_NAME_product(int32_t count, TEMPLATE_TYPE* array) {
-    TEMPLATE_TYPE result = 1;
+{{TYPE}} connx_{{ DTYPE | to_name }}_product(int32_t count, {{TYPE}}* array) {
+    {{TYPE}} result = 1;
 
     for(int32_t i = 0; i < count; i++) {
         result *= array[i];
@@ -130,6 +124,6 @@ TEMPLATE_TYPE connx_TEMPLATE_NAME_product(int32_t count, TEMPLATE_TYPE* array) {
 
     return result;
 }
-TEMPLATE_END()
+/*{% endfor %}*/
 
 // TODO: Implement basic function sfor STRING, BOOL, COMPLEX64, COMPLEX128

--- a/src/connx.c
+++ b/src/connx.c
@@ -23,11 +23,14 @@
 #include <strings.h>
 
 #if DEBUG
-#include <errno.h> // open
-#include <fcntl.h> // open
-#include <sys/stat.h> // mkdir
-#include <sys/types.h> // mkdir
+
+#include <errno.h>  // open
+#include <fcntl.h>  // open
 #include <unistd.h> // write
+
+#include <sys/stat.h>  // mkdir
+#include <sys/types.h> // mkdir
+
 #endif /* DEBUG */
 
 #include <connx/accel.h>
@@ -631,7 +634,8 @@ int connx_Graph_run(connx_Graph* graph, uint32_t input_count, connx_Tensor** inp
     // Execute operators
     for (uint32_t i = 0; i < graph->node_count; i++) {
         connx_Node* node = graph->nodes[i];
-        int ret = node->op(graph, node->output_count, node->outputs, node->input_count, node->inputs, node->attribute_count, node->attributes);
+        int ret = node->op(graph, node->output_count, node->outputs, node->input_count, node->inputs,
+                           node->attribute_count, node->attributes);
         if (ret != CONNX_OK) {
             return ret;
         }
@@ -657,7 +661,8 @@ int connx_Graph_run(connx_Graph* graph, uint32_t input_count, connx_Tensor** inp
             sprintf(path, "connx.log/%s_%u.data", name, j);
             int fd = open(path, O_CREAT | O_WRONLY, 0664);
             if (fd < 0) {
-                connx_error("Cannot create log file: %s, error_code: %d, error_message: %s\n", path, errno, strerror(errno));
+                connx_error("Cannot create log file: %s, error_code: %d, error_message: %s\n", path, errno,
+                            strerror(errno));
                 continue;
             }
 
@@ -666,7 +671,8 @@ int connx_Graph_run(connx_Graph* graph, uint32_t input_count, connx_Tensor** inp
             uint32_t dtype = tensor->dtype;
             size_t len = write(fd, &dtype, sizeof(uint32_t));
             if (len != sizeof(uint32_t)) {
-                connx_error("Cannot write log file: %s, error_code: %d, error_message: %s\n", path, errno, strerror(errno));
+                connx_error("Cannot write log file: %s, error_code: %d, error_message: %s\n", path, errno,
+                            strerror(errno));
                 close(fd);
                 continue;
             }
@@ -674,21 +680,24 @@ int connx_Graph_run(connx_Graph* graph, uint32_t input_count, connx_Tensor** inp
             uint32_t ndim = tensor->ndim;
             len = write(fd, &ndim, sizeof(uint32_t));
             if (len != sizeof(uint32_t)) {
-                connx_error("Cannot write log file: %s, error_code: %d, error_message: %s\n", path, errno, strerror(errno));
+                connx_error("Cannot write log file: %s, error_code: %d, error_message: %s\n", path, errno,
+                            strerror(errno));
                 close(fd);
                 continue;
             }
 
             len = write(fd, tensor->shape, sizeof(uint32_t) * tensor->ndim);
             if (len != sizeof(uint32_t) * tensor->ndim) {
-                connx_error("Cannot write log file: %s, error_code: %d, error_message: %s\n", path, errno, strerror(errno));
+                connx_error("Cannot write log file: %s, error_code: %d, error_message: %s\n", path, errno,
+                            strerror(errno));
                 close(fd);
                 continue;
             }
 
             len = write(fd, tensor->buffer, tensor->size);
             if (len != tensor->size) {
-                connx_error("Cannot write log file: %s, error_code: %d, error_message: %s\n", path, errno, strerror(errno));
+                connx_error("Cannot write log file: %s, error_code: %d, error_message: %s\n", path, errno,
+                            strerror(errno));
                 close(fd);
                 continue;
             }

--- a/src/opset/Asin_7.c
+++ b/src/opset/Asin_7.c
@@ -31,21 +31,17 @@ int Asin_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t out
     int32_t total = connx_Int32_product(input->ndim, input->shape);
 
     switch (input->dtype) {
-        TEMPLATE_START(FLOAT32, FLOAT64)
-#undef TEMPLATE_DTYPE
-#undef TEMPLATE_TYPE
-#define TEMPLATE_DTYPE FLOAT32
-#define TEMPLATE_TYPE float32_t
-    case TEMPLATE_DTYPE: {
-        TEMPLATE_TYPE* input_array = input->buffer;
-        TEMPLATE_TYPE* output_array = output->buffer;
+        /*{% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}*/
+    case {{ DTYPE }}: {
+        {{TYPE}}* input_array = input->buffer;
+        {{TYPE}}* output_array = output->buffer;
 
         for (int32_t i = 0; i < total; i++) {
             output_array[i] = asinf(input_array[i]);
         }
         break;
     }
-        TEMPLATE_END()
+        /*{% endfor %}*/
     default:
         connx_error("Asin: Datatype %d is not supported yet.\n", input->dtype);
         return CONNX_NOT_SUPPORTED_DATATYPE;

--- a/src/opset/Asin_7.c
+++ b/src/opset/Asin_7.c
@@ -20,9 +20,11 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
+// clang-format off
 int Asin_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-         __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-         __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                         // clang-format on
+                         __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                         __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
     connx_Tensor* input = connx_Graph_get(graph, inputs[0]);
     connx_Tensor* output = connx_Tensor_alloc_like(input);
 

--- a/src/opset/BatchNormalization_15.c
+++ b/src/opset/BatchNormalization_15.c
@@ -48,27 +48,25 @@ int BatchNormalization_{{op_version}}(connx_Graph* graph, __attribute__((unused)
     connx_Tensor* Y = connx_Tensor_alloc(X->dtype, X->ndim, X->shape);
 
     switch (X->dtype) {
-        TEMPLATE_START(FLOAT32, FLOAT64)
-#undef TEMPLATE_DTYPE
-#undef TEMPLATE_TYPE
-#define TEMPLATE_DTYPE FLOAT32
-#define TEMPLATE_TYPE float32_t
-    case TEMPLATE_DTYPE: {
-        TEMPLATE_TYPE* Y_base = (TEMPLATE_TYPE*)Y->buffer;
-        TEMPLATE_TYPE* X_base = (TEMPLATE_TYPE*)X->buffer;
+        /*{% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}*/
+    case {{ DTYPE }}: {
+        {{TYPE}}* Y_base = ({{TYPE}}*)Y->buffer;
+        {{TYPE}}* X_base = ({{TYPE}}*)X->buffer;
 
-        TEMPLATE_TYPE* scales = (TEMPLATE_TYPE*)scale->buffer;
-        TEMPLATE_TYPE* Bs = (TEMPLATE_TYPE*)B->buffer;
-        TEMPLATE_TYPE* means = (TEMPLATE_TYPE*)mean->buffer;
-        TEMPLATE_TYPE* vars = (TEMPLATE_TYPE*)var->buffer;
+        {{TYPE}}* scales = ({{TYPE}}*)scale->buffer;
+        {{TYPE}}* Bs = ({{TYPE}}*)B->buffer;
+        {{TYPE}}* means = ({{TYPE}}*)mean->buffer;
+        {{TYPE}}* vars = ({{TYPE}}*)var->buffer;
 
         for (int32_t batch = 0; batch < batch_count; batch++) {
             for (int32_t channel = 0; channel < channel_count; channel++) {
-                TEMPLATE_TYPE scale_value = scales[channel];
-                TEMPLATE_TYPE B_value = Bs[channel];
-                TEMPLATE_TYPE mean_value = means[channel];
-                TEMPLATE_TYPE sqrt_value = sqrtf(vars[channel] + epsilon);
-                TEMPLATE_TYPE scale_div_sqrt_value = scale_value / sqrt_value;
+                // clang-format off
+                {{TYPE}} scale_value = scales[channel];
+                {{TYPE}} B_value = Bs[channel];
+                {{TYPE}} mean_value = means[channel];
+                {{TYPE}} sqrt_value = sqrtf(vars[channel] + epsilon);
+                {{TYPE}} scale_div_sqrt_value = scale_value / sqrt_value;
+                // clang-format on
 
                 for (int32_t i = 0; i < unit; i++) {
                     *Y_base++ = (*X_base++ - mean_value) * scale_div_sqrt_value + B_value;
@@ -77,7 +75,7 @@ int BatchNormalization_{{op_version}}(connx_Graph* graph, __attribute__((unused)
         }
         break;
     }
-        TEMPLATE_END()
+        /*{% endfor %}*/
     default:
         connx_error("BatchNormalization: Datatype %d is not supported yet.\n", X->dtype);
         return CONNX_NOT_SUPPORTED_DATATYPE;

--- a/src/opset/BatchNormalization_15.c
+++ b/src/opset/BatchNormalization_15.c
@@ -22,9 +22,12 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
-int BatchNormalization_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-                       __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-                       __attribute__((unused)) uint32_t attribute_count, void** attributes) {
+// clang-format off
+int BatchNormalization_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count,
+                                       // clang-format on
+                                       uint32_t* outputs, __attribute__((unused)) uint32_t input_count,
+                                       uint32_t* inputs, __attribute__((unused)) uint32_t attribute_count,
+                                       void** attributes) {
     // input
     connx_Tensor* X = connx_Graph_get(graph, inputs[0]);
     connx_Tensor* scale = connx_Graph_get(graph, inputs[1]);

--- a/src/opset/Cast_13.c
+++ b/src/opset/Cast_13.c
@@ -22,9 +22,11 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
+// clang-format off
 int Cast_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-         __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-         __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                         // clang-format on
+                         __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                         __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
     connx_DataType to = *(int32_t*)attributes[0];
     connx_Tensor* input = connx_Graph_get(graph, inputs[0]);
     // FIXME: Remove this block after support string type

--- a/src/opset/Clip_1.c
+++ b/src/opset/Clip_1.c
@@ -31,20 +31,17 @@ int Clip_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t out
     connx_Tensor* Y = connx_Tensor_alloc(X->dtype, X->ndim, X->shape);
 
     switch (X->dtype) {
-        TEMPLATE_START(FLOAT16, FLOAT32, FLOAT64, UINT8, UINT16, UINT32, UINT64, INT8, INT16, INT32, INT64)
-#undef TEMPLATE_DTYPE
-#undef TEMPLATE_TYPE
-#define TEMPLATE_DTYPE FLOAT32
-#define TEMPLATE_TYPE float32_t
-#define TEMPLATE_DTYPE_MIN FLOAT32
-#define TEMPLATE_DTYPE_MAX FLOAT32
-    case TEMPLATE_DTYPE: {
-        TEMPLATE_TYPE* Y_base = (TEMPLATE_TYPE*)Y->buffer;
-        TEMPLATE_TYPE* X_base = (TEMPLATE_TYPE*)X->buffer;
+        /*{% for DTYPE, TYPE in loop_types(
+            FLOAT16, FLOAT32, FLOAT64, UINT8, UINT16, UINT32, UINT64, INT8, INT16, INT32, INT64) %}*/
+    case {{ DTYPE }}: {
+        {{TYPE}}* Y_base = ({{TYPE}}*)Y->buffer;
+        {{TYPE}}* X_base = ({{TYPE}}*)X->buffer;
 
         int32_t total = connx_Int32_product(X->ndim, X->shape);
         for (int32_t i = 0; i < total; i++) {
-            TEMPLATE_TYPE x = *X_base++;
+            // clang-format off
+            {{TYPE}} x = *X_base++;
+            // clang-format on
             if (x < min) {
                 x = min;
             }
@@ -58,7 +55,7 @@ int Clip_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t out
 
         break;
     }
-        TEMPLATE_END()
+        /*{% endfor %}*/
     default:
         connx_error("Clip: Datatype %d is not supported yet.\n", X->dtype);
         return CONNX_NOT_SUPPORTED_DATATYPE;

--- a/src/opset/Clip_1.c
+++ b/src/opset/Clip_1.c
@@ -18,9 +18,11 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
+// clang-format off
 int Clip_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-         __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-         __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                         // clang-format on
+                         __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                         __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
     // input
     connx_Tensor* X = connx_Graph_get(graph, inputs[0]);
     float32_t max = *(float32_t*)attributes[1];

--- a/src/opset/Clip_13.c
+++ b/src/opset/Clip_13.c
@@ -30,10 +30,13 @@ int Clip_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t out
     connx_Tensor* Y = connx_Tensor_alloc(X->dtype, X->ndim, X->shape);
 
     switch (X->dtype) {
-        /*{% for DTYPE, TYPE in loop_types(FLOAT16, FLOAT32, FLOAT64, UINT8, UINT16, UINT32, UINT64, INT8, INT16, INT32, INT64) %}*/
+        /*{% for DTYPE, TYPE in loop_types(
+            FLOAT16, FLOAT32, FLOAT64, UINT8, UINT16, UINT32, UINT64, INT8, INT16, INT32, INT64) %}*/
     case {{ DTYPE }}: {
+        // clang-format off
         {{TYPE}} min = CONNX_{{ DTYPE }}_MIN;
         {{TYPE}} max = CONNX_{{ DTYPE }}_MAX;
+        // clang-format on
 
         if (input_count >= 2) {
             connx_Tensor* _min = connx_Graph_get(graph, inputs[1]);
@@ -49,12 +52,16 @@ int Clip_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t out
             }
         }
 
+        // clang-format off
         {{TYPE}}* Y_base = ({{TYPE}}*)Y->buffer;
         {{TYPE}}* X_base = ({{TYPE}}*)X->buffer;
+        // clang-format on
 
         int32_t total = connx_Int32_product(X->ndim, X->shape);
         for (int32_t i = 0; i < total; i++) {
+            // clang-format off
             {{TYPE}} x = *X_base++;
+            // clang-format on
             if (x < min) {
                 x = min;
             }

--- a/src/opset/Clip_13.c
+++ b/src/opset/Clip_13.c
@@ -20,9 +20,11 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
+// clang-format off
 int Clip_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-         uint32_t input_count, uint32_t* inputs,
-         __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                         // clang-format on
+                         uint32_t input_count, uint32_t* inputs, __attribute__((unused)) uint32_t attribute_count,
+                         __attribute__((unused)) void** attributes) {
     // input
     connx_Tensor* X = connx_Graph_get(graph, inputs[0]);
     connx_Tensor* Y = connx_Tensor_alloc(X->dtype, X->ndim, X->shape);

--- a/src/opset/Clip_13.c
+++ b/src/opset/Clip_13.c
@@ -30,37 +30,31 @@ int Clip_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t out
     connx_Tensor* Y = connx_Tensor_alloc(X->dtype, X->ndim, X->shape);
 
     switch (X->dtype) {
-        TEMPLATE_START(FLOAT16, FLOAT32, FLOAT64, UINT8, UINT16, UINT32, UINT64, INT8, INT16, INT32, INT64)
-#undef TEMPLATE_DTYPE
-#undef TEMPLATE_TYPE
-#define TEMPLATE_DTYPE FLOAT32
-#define TEMPLATE_TYPE float32_t
-#define TEMPLATE_DTYPE_MIN FLOAT32
-#define TEMPLATE_DTYPE_MAX FLOAT32
-    case TEMPLATE_DTYPE: {
-        TEMPLATE_TYPE min = TEMPLATE_DTYPE_MIN;
-        TEMPLATE_TYPE max = TEMPLATE_DTYPE_MAX;
+        /*{% for DTYPE, TYPE in loop_types(FLOAT16, FLOAT32, FLOAT64, UINT8, UINT16, UINT32, UINT64, INT8, INT16, INT32, INT64) %}*/
+    case {{ DTYPE }}: {
+        {{TYPE}} min = CONNX_{{ DTYPE }}_MIN;
+        {{TYPE}} max = CONNX_{{ DTYPE }}_MAX;
 
         if (input_count >= 2) {
             connx_Tensor* _min = connx_Graph_get(graph, inputs[1]);
             if (_min != NULL) {
-                min = *(TEMPLATE_TYPE*)_min->buffer;
+                min = *({{TYPE}}*)_min->buffer;
             }
 
             if (input_count >= 3) {
                 connx_Tensor* _max = connx_Graph_get(graph, inputs[2]);
                 if (_max != NULL) {
-                    max = *(TEMPLATE_TYPE*)_max->buffer;
+                    max = *({{TYPE}}*)_max->buffer;
                 }
             }
         }
 
-        TEMPLATE_TYPE* Y_base = (TEMPLATE_TYPE*)Y->buffer;
-        TEMPLATE_TYPE* X_base = (TEMPLATE_TYPE*)X->buffer;
+        {{TYPE}}* Y_base = ({{TYPE}}*)Y->buffer;
+        {{TYPE}}* X_base = ({{TYPE}}*)X->buffer;
 
         int32_t total = connx_Int32_product(X->ndim, X->shape);
         for (int32_t i = 0; i < total; i++) {
-            TEMPLATE_TYPE x = *X_base++;
+            {{TYPE}} x = *X_base++;
             if (x < min) {
                 x = min;
             }
@@ -74,7 +68,7 @@ int Clip_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t out
 
         break;
     }
-        TEMPLATE_END()
+        /*{% endfor %}*/
     default:
         connx_error("Clip: Datatype %d is not supported yet.\n", X->dtype);
         return CONNX_NOT_SUPPORTED_DATATYPE;

--- a/src/opset/Clip_6.c
+++ b/src/opset/Clip_6.c
@@ -18,9 +18,11 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
+// clang-format off
 int Clip_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-         __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-         __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                         // clang-format on
+                         __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                         __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
     // input
     connx_Tensor* X = connx_Graph_get(graph, inputs[0]);
     float32_t max = *(float32_t*)attributes[0];

--- a/src/opset/Clip_6.c
+++ b/src/opset/Clip_6.c
@@ -31,20 +31,17 @@ int Clip_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t out
     connx_Tensor* Y = connx_Tensor_alloc(X->dtype, X->ndim, X->shape);
 
     switch (X->dtype) {
-        TEMPLATE_START(FLOAT16, FLOAT32, FLOAT64, UINT8, UINT16, UINT32, UINT64, INT8, INT16, INT32, INT64)
-#undef TEMPLATE_DTYPE
-#undef TEMPLATE_TYPE
-#define TEMPLATE_DTYPE FLOAT32
-#define TEMPLATE_TYPE float32_t
-#define TEMPLATE_DTYPE_MIN FLOAT32
-#define TEMPLATE_DTYPE_MAX FLOAT32
-    case TEMPLATE_DTYPE: {
-        TEMPLATE_TYPE* Y_base = (TEMPLATE_TYPE*)Y->buffer;
-        TEMPLATE_TYPE* X_base = (TEMPLATE_TYPE*)X->buffer;
+        /*{% for DTYPE, TYPE in loop_types(
+            FLOAT16, FLOAT32, FLOAT64, UINT8, UINT16, UINT32, UINT64, INT8, INT16, INT32, INT64) %}*/
+    case {{ DTYPE }}: {
+        {{TYPE}}* Y_base = ({{TYPE}}*)Y->buffer;
+        {{TYPE}}* X_base = ({{TYPE}}*)X->buffer;
 
         int32_t total = connx_Int32_product(X->ndim, X->shape);
         for (int32_t i = 0; i < total; i++) {
-            TEMPLATE_TYPE x = *X_base++;
+            // clang-format off
+            {{TYPE}} x = *X_base++;
+            // clang-format on
             if (x < min) {
                 x = min;
             }
@@ -58,7 +55,7 @@ int Clip_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t out
 
         break;
     }
-        TEMPLATE_END()
+        /*{% endfor %}*/
     default:
         connx_error("Clip: Datatype %d is not supported yet.\n", X->dtype);
         return CONNX_NOT_SUPPORTED_DATATYPE;

--- a/src/opset/Concat_13.c
+++ b/src/opset/Concat_13.c
@@ -61,9 +61,12 @@
    ]
 */
 
+// clang-format off
 int Concat_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-           __attribute__((unused)) uint32_t input_count, uint32_t* inputs_,
-           __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                           // clang-format on
+                           __attribute__((unused)) uint32_t input_count, uint32_t* inputs_,
+                           __attribute__((unused)) uint32_t attribute_count,
+                           __attribute__((unused)) void** attributes) {
     /*{% set SUPPORTED_DTYPES = [
        UINT8, UINT16, UINT32, UINT64,
        INT8, INT16, INT32, INT64,

--- a/src/opset/Conv_11.c
+++ b/src/opset/Conv_11.c
@@ -21,18 +21,13 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
-TEMPLATE_START(FLOAT32, FLOAT64)
-#undef TEMPLATE_DTYPE
-#undef TEMPLATE_TYPE
-#define TEMPLATE_DTYPE FLOAT32
-#define TEMPLATE_TYPE float32_t
-#define connx_TEMPLATE_NAME_add connx_Float32_add
-static void _conv_TEMPLATE_NAME(TEMPLATE_TYPE* Y_flatten, TEMPLATE_TYPE* X_flatten, int32_t feature_dim,
-                                int32_t* feature_shape, connx_Iterator* x_iter, TEMPLATE_TYPE* W_flatten,
+/*{% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}*/
+static void _conv_{{ DTYPE | to_name }}({{TYPE}}* Y_flatten, {{TYPE}}* X_flatten, int32_t feature_dim,
+                                int32_t* feature_shape, connx_Iterator* x_iter, {{TYPE}}* W_flatten,
                                 int32_t* kernel_shape, int32_t* dilations) {
 
     while (connx_Iterator_next(x_iter, 1)) {
-        TEMPLATE_TYPE y = 0;
+        {{TYPE}} y = 0;
 
         // Calculate x_patch_slices and w_slices
         connx_Slice x_patch_slices[feature_dim];
@@ -83,19 +78,19 @@ static void _conv_TEMPLATE_NAME(TEMPLATE_TYPE* Y_flatten, TEMPLATE_TYPE* X_flatt
             int32_t x_patch_offset = connx_Iterator_offset(&x_patch_iter, feature_shape);
             int32_t w_offset = connx_Iterator_offset(&w_iter, kernel_shape);
 
-            y += connx_TEMPLATE_NAME_mul_and_sum(mini_batch, (TEMPLATE_TYPE*)X_flatten + x_patch_offset,
-                                                 (TEMPLATE_TYPE*)W_flatten + w_offset);
+            y += connx_{{ DTYPE | to_name }}_mul_and_sum(mini_batch, ({{TYPE}}*)X_flatten + x_patch_offset,
+                                                 ({{TYPE}}*)W_flatten + w_offset);
         }
 
         *Y_flatten++ += y;
     }
 }
 
-struct Parameter_TEMPLATE_NAME {
-    TEMPLATE_TYPE* Y_flatten;
-    TEMPLATE_TYPE* X_flatten;
-    TEMPLATE_TYPE* B_flatten;
-    TEMPLATE_TYPE* W_flatten;
+struct Parameter_{{ DTYPE | to_name }} {
+    {{TYPE}}* Y_flatten;
+    {{TYPE}}* X_flatten;
+    {{TYPE}}* B_flatten;
+    {{TYPE}}* W_flatten;
     int32_t feature_dim;
     int32_t* feature_shape;
     int32_t* kernel_shape;
@@ -107,13 +102,13 @@ struct Parameter_TEMPLATE_NAME {
     int32_t channel_count;
 };
 
-static void* run_TEMPLATE_NAME(void* context) {
-    struct Parameter_TEMPLATE_NAME* params = context;
+static void* run_{{ DTYPE | to_name }}(void* context) {
+    struct Parameter_{{ DTYPE | to_name }}* params = context;
 
-    TEMPLATE_TYPE* Y_flatten = params->Y_flatten;
-    TEMPLATE_TYPE* X_flatten = params->X_flatten;
-    TEMPLATE_TYPE* B_flatten = params->B_flatten;
-    TEMPLATE_TYPE* W_flatten = params->W_flatten;
+    {{TYPE}}* Y_flatten = params->Y_flatten;
+    {{TYPE}}* X_flatten = params->X_flatten;
+    {{TYPE}}* B_flatten = params->B_flatten;
+    {{TYPE}}* W_flatten = params->W_flatten;
     int32_t feature_dim = params->feature_dim;
     int32_t* feature_shape = params->feature_shape;
     int32_t* kernel_shape = params->kernel_shape;
@@ -125,7 +120,7 @@ static void* run_TEMPLATE_NAME(void* context) {
     int32_t channel_count = params->channel_count;
 
     for (int32_t channel = 0; channel < channel_count; channel++) {
-        _conv_TEMPLATE_NAME(Y_flatten, X_flatten, feature_dim, feature_shape, x_iter, W_flatten, kernel_shape,
+        _conv_{{ DTYPE | to_name }}(Y_flatten, X_flatten, feature_dim, feature_shape, x_iter, W_flatten, kernel_shape,
                             dilations);
 
         X_flatten += X_unit;
@@ -133,16 +128,16 @@ static void* run_TEMPLATE_NAME(void* context) {
     }
 
     if (B_flatten != NULL) {
-        TEMPLATE_TYPE B_array[Y_unit];
-        connx_TEMPLATE_NAME_broadcast(Y_unit, B_array, 1, B_flatten);
-        connx_TEMPLATE_NAME_add(Y_unit, Y_flatten, Y_flatten, B_array);
+        {{TYPE}} B_array[Y_unit];
+        connx_{{ DTYPE | to_name }}_broadcast(Y_unit, B_array, 1, B_flatten);
+        connx_{{ DTYPE | to_name }}_add(Y_unit, Y_flatten, Y_flatten, B_array);
         B_flatten++;
     }
 
     return NULL;
 }
 
-TEMPLATE_END()
+/*{% endfor %}*/
 
 // clang-format off
 int Conv_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
@@ -249,17 +244,11 @@ int Conv_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t out
     connx_Iterator_init(&x_iter, feature_dim, x_slices);
 
     switch (X->dtype) {
-        TEMPLATE_START(FLOAT32, FLOAT64)
-#undef TEMPLATE_DTYPE
-#undef TEMPLATE_TYPE
-#define TEMPLATE_DTYPE FLOAT32
-#define TEMPLATE_TYPE float32_t
-#define connx_TEMPLATE_NAME_add connx_Float32_add
-#define connx_TEMPLATE_NAME_broadcast connx_Float32_broadcast
-    case TEMPLATE_DTYPE: {
-        TEMPLATE_TYPE* X_flatten = (TEMPLATE_TYPE*)X->buffer;
-        TEMPLATE_TYPE* Y_flatten = (TEMPLATE_TYPE*)Y->buffer;
-        TEMPLATE_TYPE* B_flatten = NULL;
+        /*{% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}*/
+    case {{ DTYPE }}: {
+        {{TYPE}}* X_flatten = ({{TYPE}}*)X->buffer;
+        {{TYPE}}* Y_flatten = ({{TYPE}}*)Y->buffer;
+        {{TYPE}}* B_flatten = NULL;
 
         int32_t batch_count = X->shape[0];
         int32_t channel_count = W->shape[1];
@@ -271,14 +260,14 @@ int Conv_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t out
         int32_t Y_unit = connx_Int32_product(feature_dim, output_shape);
 
         int32_t work_count = batch_count * group * feature_group;
-        struct Parameter_TEMPLATE_NAME works[work_count];
+        struct Parameter_{{ DTYPE | to_name }} works[work_count];
 
         for (int32_t batch = 0, work_id = 0; batch < batch_count; batch++) {
             if (B != NULL) {
-                B_flatten = (TEMPLATE_TYPE*)B->buffer;
+                B_flatten = ({{TYPE}}*)B->buffer;
             }
 
-            TEMPLATE_TYPE* W_flatten = (TEMPLATE_TYPE*)W->buffer;
+            {{TYPE}}* W_flatten = ({{TYPE}}*)W->buffer;
 
             for (int32_t g = 0, feature_map = 0; g < group; g++) {
                 for (int32_t f = 0; f < feature_group; f++, feature_map++) {
@@ -299,14 +288,14 @@ int Conv_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t out
 
                     /*
                     for (int32_t channel = 0; channel < channel_count; channel++) {
-                        _conv_TEMPLATE_NAME(Y_flatten, X_flatten + channel * X_unit, feature_dim, feature_shape,
+                        _conv_{{ DTYPE | to_name }}(Y_flatten, X_flatten + channel * X_unit, feature_dim, feature_shape,
                                             &x_iter, W_flatten + channel * W_unit, kernel_shape, dilations);
                     }
 
                     if (B_flatten != NULL) {
-                        TEMPLATE_TYPE B_array[Y_unit];
-                        connx_TEMPLATE_NAME_broadcast(Y_unit, B_array, 1, B_flatten);
-                        connx_TEMPLATE_NAME_add(Y_unit, Y_flatten, Y_flatten, B_array);
+                        {{TYPE}} B_array[Y_unit];
+                        connx_{{ DTYPE | to_name }}_broadcast(Y_unit, B_array, 1, B_flatten);
+                        connx_{{ DTYPE | to_name }}_add(Y_unit, Y_flatten, Y_flatten, B_array);
                         B_flatten++;
                     }
                     */
@@ -322,11 +311,11 @@ int Conv_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t out
             }
         }
 
-        connx_Thread_run_all(run_TEMPLATE_NAME, work_count, works, sizeof(struct Parameter_TEMPLATE_NAME));
+        connx_Thread_run_all(run_{{ DTYPE | to_name }}, work_count, works, sizeof(struct Parameter_{{ DTYPE | to_name }}));
 
         break;
     }
-        TEMPLATE_END()
+        /*{% endfor %}*/
     default:
         connx_error("Conv: Datatype %d is not supported yet.\n", X->dtype);
         return CONNX_NOT_SUPPORTED_DATATYPE;

--- a/src/opset/Conv_11.c
+++ b/src/opset/Conv_11.c
@@ -144,9 +144,11 @@ static void* run_TEMPLATE_NAME(void* context) {
 
 TEMPLATE_END()
 
+// clang-format off
 int Conv_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-        uint32_t input_count, uint32_t* inputs,
-        __attribute__((unused)) uint32_t attribute_count, void** attributes) {
+                         // clang-format on
+                         uint32_t input_count, uint32_t* inputs, __attribute__((unused)) uint32_t attribute_count,
+                         void** attributes) {
     // inputs
     connx_Tensor* X = connx_Graph_get(graph, inputs[0]);
     connx_Tensor* W = connx_Graph_get(graph, inputs[1]);

--- a/src/opset/Cos_7.c
+++ b/src/opset/Cos_7.c
@@ -20,9 +20,11 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
+// clang-format off
 int Cos_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-        __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-        __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                        // clang-format on
+                        __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                        __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
     connx_Tensor* X = connx_Graph_get(graph, inputs[0]);
     connx_Tensor* Y = connx_Tensor_alloc_like(X);
     if (Y == NULL) {

--- a/src/opset/Cosh_9.c
+++ b/src/opset/Cosh_9.c
@@ -20,9 +20,11 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
+// clang-format off
 int Cosh_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-         __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-         __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                         // clang-format on
+                         __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                         __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
     connx_Tensor* X = connx_Graph_get(graph, inputs[0]);
     connx_Tensor* Y = connx_Tensor_alloc_like(X);
     if (Y == NULL) {

--- a/src/opset/Exp_13.c
+++ b/src/opset/Exp_13.c
@@ -20,9 +20,11 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
+// clang-format off
 int Exp_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-        __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-        __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                        // clang-format on
+                        __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                        __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
     connx_Tensor* X = connx_Graph_get(graph, inputs[0]);
     connx_Tensor* Y = connx_Tensor_alloc_like(X);
     if (Y == NULL) {

--- a/src/opset/Gather_13.c
+++ b/src/opset/Gather_13.c
@@ -20,9 +20,12 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
+// clang-format off
 int Gather_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-           __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-           __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                           // clang-format on
+                           __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                           __attribute__((unused)) uint32_t attribute_count,
+                           __attribute__((unused)) void** attributes) {
     /*{% set supported_dtypes = [
         UINT8,
         UINT16,

--- a/src/opset/GlobalAveragePool_1.c
+++ b/src/opset/GlobalAveragePool_1.c
@@ -48,18 +48,16 @@ int GlobalAveragePool_{{op_version}}(connx_Graph* graph, __attribute__((unused))
     connx_Tensor* Y = connx_Tensor_alloc(X->dtype, X->ndim, Y_shape);
 
     switch (X->dtype) {
-        TEMPLATE_START(FLOAT32, FLOAT64)
-#undef TEMPLATE_DTYPE
-#undef TEMPLATE_TYPE
-#define TEMPLATE_DTYPE FLOAT32
-#define TEMPLATE_TYPE float32_t
-    case TEMPLATE_DTYPE: {
-        TEMPLATE_TYPE* Y_base = (TEMPLATE_TYPE*)Y->buffer;
-        TEMPLATE_TYPE* X_base = (TEMPLATE_TYPE*)X->buffer;
+        /*{% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64) %}*/
+    case {{ DTYPE }}: {
+        {{TYPE}}* Y_base = ({{TYPE}}*)Y->buffer;
+        {{TYPE}}* X_base = ({{TYPE}}*)X->buffer;
 
         for (int32_t batch = 0; batch < batch_count; batch++) {
             for (int32_t channel = 0; channel < channel_count; channel++) {
-                TEMPLATE_TYPE average = 0;
+                // clang-format off
+                {{TYPE}} average = 0;
+                // clang-format on
                 for (int32_t i = 0; i < unit; i++) {
                     average += (*X_base++) / unit;
                 }
@@ -69,7 +67,7 @@ int GlobalAveragePool_{{op_version}}(connx_Graph* graph, __attribute__((unused))
         }
         break;
     }
-        TEMPLATE_END()
+        /*{% endfor %}*/
     default:
         connx_error("GlobalAveragePool: Datatype %d is not supported yet.\n", X->dtype);
         return CONNX_NOT_SUPPORTED_DATATYPE;

--- a/src/opset/GlobalAveragePool_1.c
+++ b/src/opset/GlobalAveragePool_1.c
@@ -22,9 +22,12 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
-int GlobalAveragePool_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-                      __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-                      __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+// clang-format off
+int GlobalAveragePool_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count,
+                                      // clang-format on
+                                      uint32_t* outputs, __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                                      __attribute__((unused)) uint32_t attribute_count,
+                                      __attribute__((unused)) void** attributes) {
     // input
     connx_Tensor* X = connx_Graph_get(graph, inputs[0]);
 

--- a/src/opset/GlobalMaxPool_1.c
+++ b/src/opset/GlobalMaxPool_1.c
@@ -22,9 +22,12 @@
 
 /*{% set supported_dtypes = ['FLOAT32', 'FLOAT64'] %}*/
 
+// clang-format off
 int GlobalMaxPool_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-                  __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-                  __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                                  // clang-format on
+                                  __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                                  __attribute__((unused)) uint32_t attribute_count,
+                                  __attribute__((unused)) void** attributes) {
     // input
     connx_Tensor* X = connx_Graph_get(graph, inputs[0]);
 

--- a/src/opset/Identity_16.c
+++ b/src/opset/Identity_16.c
@@ -18,9 +18,12 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
+// clang-format off
 int Identity_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-             __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-             __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                             // clang-format on
+                             __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                             __attribute__((unused)) uint32_t attribute_count,
+                             __attribute__((unused)) void** attributes) {
     connx_Tensor* input = connx_Graph_get(graph, inputs[0]);
     connx_Tensor* output = connx_Tensor_copy(input);
 

--- a/src/opset/LeakyRelu_16.c
+++ b/src/opset/LeakyRelu_16.c
@@ -18,9 +18,12 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
+// clang-format off
 int LeakyRelu_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-              __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-              __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                              // clang-format on
+                              __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                              __attribute__((unused)) uint32_t attribute_count,
+                              __attribute__((unused)) void** attributes) {
     float32_t alpha = *(float32_t*)attributes[0];
     connx_Tensor* X = connx_Graph_get(graph, inputs[0]);
     connx_Tensor* Y = connx_Tensor_alloc_like(X);

--- a/src/opset/Log_13.c
+++ b/src/opset/Log_13.c
@@ -20,9 +20,11 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
+// clang-format off
 int Log_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-        __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-        __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                        // clang-format on
+                        __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                        __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
     connx_Tensor* X = connx_Graph_get(graph, inputs[0]);
     connx_Tensor* Y = connx_Tensor_alloc_like(X);
     if (Y == NULL) {

--- a/src/opset/MatMul_13.c
+++ b/src/opset/MatMul_13.c
@@ -43,9 +43,12 @@ static TEMPLATE_TYPE* get_TEMPLATE_NAME_col(int32_t temp_count, TEMPLATE_TYPE* t
 }
 TEMPLATE_END()
 
+// clang-format off
 int MatMul_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-           __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-           __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                           // clang-format on
+                           __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                           __attribute__((unused)) uint32_t attribute_count,
+                           __attribute__((unused)) void** attributes) {
     connx_Tensor* A = connx_Graph_get(graph, inputs[0]);
     connx_Tensor* B = connx_Graph_get(graph, inputs[1]);
 

--- a/src/opset/MatMul_13.c
+++ b/src/opset/MatMul_13.c
@@ -18,30 +18,31 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
-TEMPLATE_START(FLOAT32, FLOAT64, UINT32, UINT64, INT32, INT64)
-#undef TEMPLATE_DTYPE
-#undef TEMPLATE_TYPE
-#define TEMPLATE_DTYPE FLOAT32
-#define TEMPLATE_TYPE float32_t
-#define connx_TEMPLATE_NAME_broadcast connx_Float32_broadcast
-static TEMPLATE_TYPE* get_TEMPLATE_NAME_row(int32_t temp_count, TEMPLATE_TYPE* temp, int32_t array_count,
-                                            TEMPLATE_TYPE* array, int32_t row) {
+/*{% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64, UINT32, UINT64, INT32, INT64) %}*/
+// clang-format off
+static {{TYPE}}* get_{{ DTYPE | to_name }}_row(int32_t temp_count, {{TYPE}}* temp, int32_t array_count,
+                                            {{TYPE}}* array, int32_t row) {
+    // clang-format on
     if (array_count >= temp_count) {
         return array + row * array_count;
     } else {
-        connx_TEMPLATE_NAME_broadcast(temp_count, temp, array_count, array + row * array_count);
+        // clang-format off
+        connx_{{ DTYPE | to_name }}_broadcast(temp_count, temp, array_count, array + row * array_count);
+        // clang-format on
         return temp;
     }
 }
 
-static TEMPLATE_TYPE* get_TEMPLATE_NAME_col(int32_t temp_count, TEMPLATE_TYPE* temp, int32_t array_count,
-                                            TEMPLATE_TYPE* array, int32_t col) {
+// clang-format off
+static {{TYPE}}* get_{{ DTYPE | to_name }}_col(int32_t temp_count, {{TYPE}}* temp, int32_t array_count,
+                                            {{TYPE}}* array, int32_t col) {
+    // clang-format on
     for (int32_t i = 0; i < temp_count; i++) {
         temp[i] = array[i * array_count + col];
     }
     return temp;
 }
-TEMPLATE_END()
+/*{% endfor %}*/
 
 // clang-format off
 int MatMul_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
@@ -87,43 +88,47 @@ int MatMul_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t o
     int32_t Y_total = connx_Int32_product(Y->ndim, Y->shape);
 
     switch (A->dtype) {
-        TEMPLATE_START(FLOAT32, FLOAT64, UINT32, UINT64, INT32, INT64)
-#undef TEMPLATE_DTYPE
-#undef TEMPLATE_TYPE
-#define TEMPLATE_DTYPE FLOAT32
-#define TEMPLATE_TYPE float32_t
-#define connx_TEMPLATE_NAME_mul connx_Float32_mul
-#define connx_TEMPLATE_NAME_sum connx_Float32_sum
-    case TEMPLATE_DTYPE: {
-        TEMPLATE_TYPE* A_array = A->buffer;
-        TEMPLATE_TYPE* B_array = B->buffer;
-        TEMPLATE_TYPE* Y_array = Y->buffer;
+        /*{% for DTYPE, TYPE in loop_types(FLOAT32, FLOAT64, UINT32, UINT64, INT32, INT64) %}*/
+    case {{ DTYPE }}: {
+        {{TYPE}}* A_array = A->buffer;
+        {{TYPE}}* B_array = B->buffer;
+        {{TYPE}}* Y_array = Y->buffer;
 
         int32_t count = A_col > B_row ? A_col : B_row; // count = MAX(A_col, B_row)
-        TEMPLATE_TYPE tmp_a[count];
-        TEMPLATE_TYPE tmp_b[count];
-        TEMPLATE_TYPE tmp_mul[count];
+        // clang-format off
+        {{TYPE}} tmp_a[count];
+        {{TYPE}} tmp_b[count];
+        {{TYPE}} tmp_mul[count];
+        // clang-format on
 
         for (int32_t Y_idx = 0, A_idx = 0, B_idx = 0; Y_idx < Y_total;
              Y_idx += Y_unit, A_idx = (A_idx + A_unit) % A_total, B_idx = (B_idx + B_unit) % B_total) {
 
             for (int32_t col_idx = 0; col_idx < Y_col; col_idx++) {
-                TEMPLATE_TYPE* b = get_TEMPLATE_NAME_col(count, tmp_a, B_col, B_array + B_idx, col_idx);
+                // clang-format off
+                {{TYPE}}* b = get_{{ DTYPE | to_name }}_col(count, tmp_a, B_col, B_array + B_idx, col_idx);
+                // clang-format on
 
                 for (int32_t row_idx = 0; row_idx < Y_row; row_idx++) {
-                    TEMPLATE_TYPE* a = get_TEMPLATE_NAME_row(count, tmp_b, A_col, A_array + A_idx, row_idx);
+                    // clang-format off
+                    {{TYPE}}* a = get_{{ DTYPE | to_name }}_row(count, tmp_b, A_col, A_array + A_idx, row_idx);
+                    // clang-format on
 
                     // Mul
-                    connx_TEMPLATE_NAME_mul(count, tmp_mul, a, b);
+                    // clang-format off
+                    connx_{{ DTYPE | to_name }}_mul(count, tmp_mul, a, b);
+                    // clang-format on
 
                     // Sum
-                    Y_array[Y_idx + row_idx * Y_col + col_idx] = connx_TEMPLATE_NAME_sum(count, tmp_mul);
+                    // clang-format off
+                    Y_array[Y_idx + row_idx * Y_col + col_idx] = connx_{{ DTYPE | to_name }}_sum(count, tmp_mul);
+                    // clang-format on
                 }
             }
         }
         break;
     }
-        TEMPLATE_END()
+        /*{% endfor %}*/
     default:
         connx_error("MatMul: Datatype %d is not supported yet.\n", A->dtype);
         return CONNX_NOT_SUPPORTED_DATATYPE;

--- a/src/opset/MaxPool_12.c
+++ b/src/opset/MaxPool_12.c
@@ -22,9 +22,11 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
+// clang-format off
 int MaxPool_{{op_version}}(connx_Graph* graph, uint32_t output_count, uint32_t* outputs,
-        __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-        __attribute__((unused)) uint32_t attribute_count, void** attributes) {
+                            // clang-format on
+                            __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                            __attribute__((unused)) uint32_t attribute_count, void** attributes) {
     // inputs
     connx_Tensor* X = connx_Graph_get(graph, inputs[0]);
 

--- a/src/opset/MaxPool_12.c
+++ b/src/opset/MaxPool_12.c
@@ -185,7 +185,9 @@ int MaxPool_{{op_version}}(connx_Graph* graph, uint32_t output_count, uint32_t* 
                 connx_Iterator_init(&x_iter, feature_dim, x_slices);
 
                 while (connx_Iterator_next(&x_iter, 1)) {
+                    // clang-format off
                     {{TYPE}} y = 0;
+                    // clang-format on
                     int64_t argmax_idx = -1;
                     int32_t k_idx[feature_dim];
 
@@ -225,7 +227,9 @@ int MaxPool_{{op_version}}(connx_Graph* graph, uint32_t output_count, uint32_t* 
                     if (x_patch_batch == 1) {
                         while (connx_Iterator_next(&x_patch_iter, x_patch_batch)) {
                             int32_t x_patch_offset = connx_Iterator_offset(&x_patch_iter, feature_shape);
+                            // clang-format off
                             {{TYPE}} tmp_y = X_flatten[x_patch_offset];
+                            // clang-format on
                             if (kernel_offset < 0 || tmp_y > y) {
                                 y = tmp_y;
                                 kernel_offset = X_offset + x_patch_iter.idx;
@@ -234,15 +238,17 @@ int MaxPool_{{op_version}}(connx_Graph* graph, uint32_t output_count, uint32_t* 
                     } else {
                         while (connx_Iterator_next(&x_patch_iter, x_patch_batch)) {
                             int32_t x_patch_offset = connx_Iterator_offset(&x_patch_iter, feature_shape);
-
+                            // clang-format off
                             {{TYPE}} tmp_y = CONNX_{{DTYPE}}_MIN;
+                            // clang-format on
                             for (int i = 0; i < x_patch_batch; i++) {
                                 if (X_flatten[x_patch_offset + i] > tmp_y) {
                                     tmp_y = X_flatten[x_patch_offset + i];
                                 }
                             }
-                            int32_t tmp_kernel_offset =
-                                connx_{{DTYPE | to_name }}_argmax(x_patch_batch, &tmp_y, X_flatten + x_patch_offset);
+                            // clang-format off
+                            int32_t tmp_kernel_offset = connx_{{DTYPE | to_name }}_argmax(x_patch_batch, &tmp_y, X_flatten + x_patch_offset);
+                            // clang-format on
 
                             if (kernel_offset < 0 || tmp_y > y) {
                                 y = tmp_y;

--- a/src/opset/NonZero_13.c
+++ b/src/opset/NonZero_13.c
@@ -34,9 +34,12 @@ static inline void get_indices(int32_t ndim, int32_t* shape, int32_t offset, int
     }
 }
 
+// clang-format off
 int NonZero_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-            __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-            __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                            // clang-format on
+                            __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                            __attribute__((unused)) uint32_t attribute_count,
+                            __attribute__((unused)) void** attributes) {
     connx_Tensor* X = connx_Graph_get(graph, inputs[0]);
 
     int32_t total = connx_Int32_product(X->ndim, X->shape);

--- a/src/opset/Not_1.c
+++ b/src/opset/Not_1.c
@@ -21,9 +21,11 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
+// clang-format off
 int Not_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-        __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-        __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                        // clang-format on
+                        __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                        __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
     // Inputs
     connx_Tensor* X = connx_Graph_get(graph, inputs[0]);
 

--- a/src/opset/Relu_14.c
+++ b/src/opset/Relu_14.c
@@ -18,9 +18,11 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
+// clang-format off
 int Relu_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-         __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-         __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                         // clang-format on
+                         __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                         __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
     connx_Tensor* X = connx_Graph_get(graph, inputs[0]);
     connx_Tensor* Y = connx_Tensor_alloc_like(X);
     if (Y == NULL) {

--- a/src/opset/Relu_14.c
+++ b/src/opset/Relu_14.c
@@ -32,21 +32,17 @@ int Relu_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t out
     int32_t total = connx_Int32_product(X->ndim, X->shape);
 
     switch (X->dtype) {
-        TEMPLATE_START(FLOAT32, INT32, INT8, INT16, INT64, FLOAT64)
-#undef TEMPLATE_DTYPE
-#undef TEMPLATE_TYPE
-#define TEMPLATE_DTYPE FLOAT32
-#define TEMPLATE_TYPE float32_t
-    case TEMPLATE_DTYPE: {
-        TEMPLATE_TYPE* X_array = X->buffer;
-        TEMPLATE_TYPE* Y_array = Y->buffer;
+        /*{% for DTYPE, TYPE in loop_types(FLOAT32, INT32, INT8, INT16, INT64, FLOAT64) %}*/
+    case {{ DTYPE }}: {
+        {{TYPE}}* X_array = X->buffer;
+        {{TYPE}}* Y_array = Y->buffer;
 
         for (int32_t i = 0; i < total; i++) {
             Y_array[i] = X_array[i] < 0 ? 0 : X_array[i];
         }
         break;
     }
-        TEMPLATE_END()
+        /*{% endfor %}*/
     default:
         connx_error("Relu: Datatype %d is not supported yet.\n", X->dtype);
         return CONNX_NOT_SUPPORTED_DATATYPE;

--- a/src/opset/Reshape_14.c
+++ b/src/opset/Reshape_14.c
@@ -18,9 +18,11 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
+// clang-format off
 int Reshape_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-            __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-            __attribute__((unused)) uint32_t attribute_count, void** attributes) {
+                            // clang-format on
+                            __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                            __attribute__((unused)) uint32_t attribute_count, void** attributes) {
     connx_Tensor* data = connx_Graph_get(graph, inputs[0]);
     connx_Tensor* shape = connx_Graph_get(graph, inputs[1]);
     int32_t allowzero = *(int32_t*)attributes[0];

--- a/src/opset/Resize_13.c
+++ b/src/opset/Resize_13.c
@@ -93,8 +93,9 @@ static enum NEAREST_MODE get_nearest_mode(const char* mode) {
     return -1;
 }
 
-
-static void calc_coord(float32_t* bases, float32_t* steps, enum COORDINATE_TRANSFORMATION_MODE coordinate_transformation_mode, int32_t ndim, int32_t* X_shape, float32_t* scales) {
+static void calc_coord(float32_t* bases, float32_t* steps,
+                       enum COORDINATE_TRANSFORMATION_MODE coordinate_transformation_mode, int32_t ndim,
+                       int32_t* X_shape, float32_t* scales) {
     switch (coordinate_transformation_mode) {
     case HALF_PIXEL:
         for (int32_t i = 0; i < ndim; i++) {
@@ -121,7 +122,7 @@ static void calc_coord(float32_t* bases, float32_t* steps, enum COORDINATE_TRANS
             if (Y_length == 1) {
                 steps[i] = 0;
             } else {
-                steps[i] = (float32_t)(X_shape[i] - 1)/ (float32_t)(Y_length - 1);
+                steps[i] = (float32_t)(X_shape[i] - 1) / (float32_t)(Y_length - 1);
             }
         }
         break;
@@ -188,12 +189,16 @@ static int32_t _ceil(float32_t f) {
     }
 }
 
-#define bound(v, size) ((v) < 0 ? 0 : (v) >= (size) ? (size) - 1 : (v))
+#define bound(v, size) ((v) < 0 ? 0 : (v) >= (size) ? (size)-1 : (v))
 
 /*{% for DTYPE, TYPE in loop_types(*supported_data_types) %}*/
-static void interpolate_2d_nearest_{{DTYPE}}({{TYPE}}* Y_array, int32_t* X_shape, {{TYPE}}* X_array, int32_t* Y_shape, float32_t* bases, float32_t* steps, enum NEAREST_MODE nearest_mode, int32_t loop_count) {
+// clang-format off
+static void interpolate_2d_nearest_{{DTYPE}}({{TYPE}} * Y_array, int32_t* X_shape, {{TYPE}} * X_array,
+                                              // clang-format on
+                                              int32_t* Y_shape, float32_t* bases, float32_t* steps,
+                                              enum NEAREST_MODE nearest_mode, int32_t loop_count) {
 
-    int32_t(*round)(float32_t);
+    int32_t (*round)(float32_t);
 
     switch (nearest_mode) {
     case ROUND_PREFER_FLOOR:
@@ -242,7 +247,11 @@ static void interpolate_2d_nearest_{{DTYPE}}({{TYPE}}* Y_array, int32_t* X_shape
 /*{% endfor %}*/
 
 /*{% for DTYPE, TYPE in loop_types(*supported_data_types) %}*/
-static void interpolate_2d_linear_{{DTYPE}}({{TYPE}}* Y_array, int32_t* X_shape, {{TYPE}}* X_array, int32_t* Y_shape, float32_t* bases, float32_t* steps, bool exclude_outside, int32_t loop_count) {
+// clang-format off
+static void interpolate_2d_linear_{{DTYPE}}({{TYPE}} * Y_array, int32_t* X_shape, {{TYPE}} * X_array, int32_t* Y_shape,
+                                             // clang-format on
+                                             float32_t* bases, float32_t* steps, bool exclude_outside,
+                                             int32_t loop_count) {
 
     int32_t X_step = connx_Int32_product(2, X_shape);
 
@@ -259,10 +268,8 @@ static void interpolate_2d_linear_{{DTYPE}}({{TYPE}}* Y_array, int32_t* X_shape,
                 float32_t ratio_y1 = y1_idx - y1_idx_int;
 
                 // coeffects
-                float32_t coeffects[4] = {
-                    (1 - ratio_y0) * (1 - ratio_y1), (1 - ratio_y0) * ratio_y1,
-                    ratio_y0 * (1 - ratio_y1), ratio_y0 * ratio_y1
-                };
+                float32_t coeffects[4] = {(1 - ratio_y0) * (1 - ratio_y1), (1 - ratio_y0) * ratio_y1,
+                                          ratio_y0 * (1 - ratio_y1), ratio_y0 * ratio_y1};
 
                 // exclude outside
                 if (exclude_outside) {
@@ -305,14 +312,13 @@ static void interpolate_2d_linear_{{DTYPE}}({{TYPE}}* Y_array, int32_t* X_shape,
                 }
 
                 float32_t values[4] = {
-                        X_array[bound(y0_idx_int, X_shape[0]) * X_shape[1] + bound(y1_idx_int, X_shape[1])],
-                        X_array[bound(y0_idx_int, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 1, X_shape[1])],
-                        X_array[bound(y0_idx_int + 1, X_shape[0]) * X_shape[1] + bound(y1_idx_int, X_shape[1])],
-                        X_array[bound(y0_idx_int + 1, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 1, X_shape[1])]
-                    };
+                    X_array[bound(y0_idx_int, X_shape[0]) * X_shape[1] + bound(y1_idx_int, X_shape[1])],
+                    X_array[bound(y0_idx_int, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 1, X_shape[1])],
+                    X_array[bound(y0_idx_int + 1, X_shape[0]) * X_shape[1] + bound(y1_idx_int, X_shape[1])],
+                    X_array[bound(y0_idx_int + 1, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 1, X_shape[1])]};
 
-                *Y_array++ = ({{TYPE}})(coeffects[0] * values[0] + coeffects[1] * values[1] + 
-                                        coeffects[2] * values[2] + coeffects[3] * values[3]);
+                *Y_array++ = ({{TYPE}})(coeffects[0] * values[0] + coeffects[1] * values[1] + coeffects[2] * values[2] +
+                                        coeffects[3] * values[3]);
 
                 y1_idx += steps[1];
             }
@@ -326,7 +332,11 @@ static void interpolate_2d_linear_{{DTYPE}}({{TYPE}}* Y_array, int32_t* X_shape,
 /*{% endfor %}*/
 
 /*{% for DTYPE, TYPE in loop_types(*supported_data_types) %}*/
-static void interpolate_2d_cubic_{{DTYPE}}({{TYPE}}* Y_array, int32_t* X_shape, {{TYPE}}* X_array, int32_t* Y_shape, float32_t* bases, float32_t* steps, bool exclude_outside, float32_t cubic_coeff_a, int32_t loop_count) {
+// clang-format off
+static void interpolate_2d_cubic_{{DTYPE}}({{TYPE}} * Y_array, int32_t* X_shape, {{TYPE}} * X_array, int32_t* Y_shape,
+                                            // clang-format on
+                                            float32_t* bases, float32_t* steps, bool exclude_outside,
+                                            float32_t cubic_coeff_a, int32_t loop_count) {
 
     int32_t X_step = connx_Int32_product(2, X_shape);
 
@@ -344,18 +354,26 @@ static void interpolate_2d_cubic_{{DTYPE}}({{TYPE}}* Y_array, int32_t* X_shape, 
 
                 // coeffects
                 float32_t y0_coeffects[4] = {
-                        ((cubic_coeff_a * (y0_ratio + 1) - 5 * cubic_coeff_a) * (y0_ratio + 1) + 8 * cubic_coeff_a) * (y0_ratio + 1) - 4 * cubic_coeff_a,
-                        ((cubic_coeff_a + 2) * y0_ratio - (cubic_coeff_a + 3)) * y0_ratio * y0_ratio + 1,
-                        ((cubic_coeff_a + 2) * (1 - y0_ratio) - (cubic_coeff_a + 3)) * (1 - y0_ratio) * (1 - y0_ratio) + 1,
-                        ((cubic_coeff_a * ((1 - y0_ratio) + 1) - 5 * cubic_coeff_a) * ((1 - y0_ratio) + 1) + 8 * cubic_coeff_a) * ((1 - y0_ratio) + 1) - 4 * cubic_coeff_a
-                    };
+                    ((cubic_coeff_a * (y0_ratio + 1) - 5 * cubic_coeff_a) * (y0_ratio + 1) + 8 * cubic_coeff_a) *
+                            (y0_ratio + 1) -
+                        4 * cubic_coeff_a,
+                    ((cubic_coeff_a + 2) * y0_ratio - (cubic_coeff_a + 3)) * y0_ratio * y0_ratio + 1,
+                    ((cubic_coeff_a + 2) * (1 - y0_ratio) - (cubic_coeff_a + 3)) * (1 - y0_ratio) * (1 - y0_ratio) + 1,
+                    ((cubic_coeff_a * ((1 - y0_ratio) + 1) - 5 * cubic_coeff_a) * ((1 - y0_ratio) + 1) +
+                     8 * cubic_coeff_a) *
+                            ((1 - y0_ratio) + 1) -
+                        4 * cubic_coeff_a};
 
                 float32_t y1_coeffects[4] = {
-                        ((cubic_coeff_a * (y1_ratio + 1) - 5 * cubic_coeff_a) * (y1_ratio + 1) + 8 * cubic_coeff_a) * (y1_ratio + 1) - 4 * cubic_coeff_a,
-                        ((cubic_coeff_a + 2) * y1_ratio - (cubic_coeff_a + 3)) * y1_ratio * y1_ratio + 1,
-                        ((cubic_coeff_a + 2) * (1 - y1_ratio) - (cubic_coeff_a + 3)) * (1 - y1_ratio) * (1 - y1_ratio) + 1,
-                        ((cubic_coeff_a * ((1 - y1_ratio) + 1) - 5 * cubic_coeff_a) * ((1 - y1_ratio) + 1) + 8 * cubic_coeff_a) * ((1 - y1_ratio) + 1) - 4 * cubic_coeff_a
-                    };
+                    ((cubic_coeff_a * (y1_ratio + 1) - 5 * cubic_coeff_a) * (y1_ratio + 1) + 8 * cubic_coeff_a) *
+                            (y1_ratio + 1) -
+                        4 * cubic_coeff_a,
+                    ((cubic_coeff_a + 2) * y1_ratio - (cubic_coeff_a + 3)) * y1_ratio * y1_ratio + 1,
+                    ((cubic_coeff_a + 2) * (1 - y1_ratio) - (cubic_coeff_a + 3)) * (1 - y1_ratio) * (1 - y1_ratio) + 1,
+                    ((cubic_coeff_a * ((1 - y1_ratio) + 1) - 5 * cubic_coeff_a) * ((1 - y1_ratio) + 1) +
+                     8 * cubic_coeff_a) *
+                            ((1 - y1_ratio) + 1) -
+                        4 * cubic_coeff_a};
 
                 float32_t coeffects[16];
                 for (int32_t y0_co_idx = 0; y0_co_idx < 4; y0_co_idx++) {
@@ -500,26 +518,26 @@ static void interpolate_2d_cubic_{{DTYPE}}({{TYPE}}* Y_array, int32_t* X_shape, 
                 }
 
                 float32_t values[16] = {
-                        X_array[bound(y0_idx_int - 1, X_shape[0]) * X_shape[1] + bound(y1_idx_int - 1, X_shape[1])],
-                        X_array[bound(y0_idx_int - 1, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 0, X_shape[1])],
-                        X_array[bound(y0_idx_int - 1, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 1, X_shape[1])],
-                        X_array[bound(y0_idx_int - 1, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 2, X_shape[1])],
+                    X_array[bound(y0_idx_int - 1, X_shape[0]) * X_shape[1] + bound(y1_idx_int - 1, X_shape[1])],
+                    X_array[bound(y0_idx_int - 1, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 0, X_shape[1])],
+                    X_array[bound(y0_idx_int - 1, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 1, X_shape[1])],
+                    X_array[bound(y0_idx_int - 1, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 2, X_shape[1])],
 
-                        X_array[bound(y0_idx_int + 0, X_shape[0]) * X_shape[1] + bound(y1_idx_int - 1, X_shape[1])],
-                        X_array[bound(y0_idx_int + 0, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 0, X_shape[1])],
-                        X_array[bound(y0_idx_int + 0, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 1, X_shape[1])],
-                        X_array[bound(y0_idx_int + 0, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 2, X_shape[1])],
+                    X_array[bound(y0_idx_int + 0, X_shape[0]) * X_shape[1] + bound(y1_idx_int - 1, X_shape[1])],
+                    X_array[bound(y0_idx_int + 0, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 0, X_shape[1])],
+                    X_array[bound(y0_idx_int + 0, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 1, X_shape[1])],
+                    X_array[bound(y0_idx_int + 0, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 2, X_shape[1])],
 
-                        X_array[bound(y0_idx_int + 1, X_shape[0]) * X_shape[1] + bound(y1_idx_int - 1, X_shape[1])],
-                        X_array[bound(y0_idx_int + 1, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 0, X_shape[1])],
-                        X_array[bound(y0_idx_int + 1, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 1, X_shape[1])],
-                        X_array[bound(y0_idx_int + 1, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 2, X_shape[1])],
+                    X_array[bound(y0_idx_int + 1, X_shape[0]) * X_shape[1] + bound(y1_idx_int - 1, X_shape[1])],
+                    X_array[bound(y0_idx_int + 1, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 0, X_shape[1])],
+                    X_array[bound(y0_idx_int + 1, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 1, X_shape[1])],
+                    X_array[bound(y0_idx_int + 1, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 2, X_shape[1])],
 
-                        X_array[bound(y0_idx_int + 2, X_shape[0]) * X_shape[1] + bound(y1_idx_int - 1, X_shape[1])],
-                        X_array[bound(y0_idx_int + 2, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 0, X_shape[1])],
-                        X_array[bound(y0_idx_int + 2, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 1, X_shape[1])],
-                        X_array[bound(y0_idx_int + 2, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 2, X_shape[1])],
-                    };
+                    X_array[bound(y0_idx_int + 2, X_shape[0]) * X_shape[1] + bound(y1_idx_int - 1, X_shape[1])],
+                    X_array[bound(y0_idx_int + 2, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 0, X_shape[1])],
+                    X_array[bound(y0_idx_int + 2, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 1, X_shape[1])],
+                    X_array[bound(y0_idx_int + 2, X_shape[0]) * X_shape[1] + bound(y1_idx_int + 2, X_shape[1])],
+                };
 
                 float32_t v = 0;
                 for (int32_t k = 0; k < 16; k++) {
@@ -538,16 +556,20 @@ static void interpolate_2d_cubic_{{DTYPE}}({{TYPE}}* Y_array, int32_t* X_shape, 
 }
 /*{% endfor %}*/
 
+// clang-format off
 int Resize_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-        uint32_t input_count, uint32_t* inputs, __attribute__((unused)) uint32_t attribute_count, void** attributes) {
+                           // clang-format on
+                           uint32_t input_count, uint32_t* inputs, __attribute__((unused)) uint32_t attribute_count,
+                           void** attributes) {
     // Inputs
-    connx_Tensor* X = connx_Graph_get(graph, inputs[0]); // T1
-    __attribute__((unused)) connx_Tensor* _roi = connx_Graph_get(graph, inputs[1]); // T2
-    connx_Tensor* _scales = connx_Graph_get(graph, inputs[2]); // float32 (can be empty)
+    connx_Tensor* X = connx_Graph_get(graph, inputs[0]);                               // T1
+    __attribute__((unused)) connx_Tensor* _roi = connx_Graph_get(graph, inputs[1]);    // T2
+    connx_Tensor* _scales = connx_Graph_get(graph, inputs[2]);                         // float32 (can be empty)
     connx_Tensor* _sizes = input_count > 3 ? connx_Graph_get(graph, inputs[3]) : NULL; // int64 (optional)
 
     // Attributes
-    enum COORDINATE_TRANSFORMATION_MODE coordinate_transformation_mode = get_coordinate_transformation_mode(attributes[0]);
+    enum COORDINATE_TRANSFORMATION_MODE coordinate_transformation_mode =
+        get_coordinate_transformation_mode(attributes[0]);
     if (coordinate_transformation_mode < 0) {
         connx_error("coordinate_transformation_mode '%s' is not supported yet", (char*)attributes[0]);
         return CONNX_NOT_SUPPORTED_ATTRIBUTE;
@@ -635,31 +657,39 @@ int Resize_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t o
     switch (X->ndim - 2) {
     case 2: // 2d interpolation
         switch (X->dtype) {
-        /*{% for DTYPE, TYPE in loop_types(*supported_data_types) %}*/
-            case {{DTYPE}}: {
-                {{TYPE}}* Y_buffer = ({{TYPE}}*)Y->buffer;
-                {{TYPE}}* X_buffer = ({{TYPE}}*)X->buffer;
+            /*{% for DTYPE, TYPE in loop_types(*supported_data_types) %}*/
+        case {{ DTYPE }}: {
+            {{TYPE}}* Y_buffer = ({{TYPE}}*)Y->buffer;
+            {{TYPE}}* X_buffer = ({{TYPE}}*)X->buffer;
 
-                switch (mode) {
-                    case NEAREST:
-                        interpolate_2d_nearest_{{DTYPE}}(Y_buffer, X->shape + 2, X_buffer, Y->shape + 2, bases, steps, nearest_mode, loop_count);
+            switch (mode) {
+            case NEAREST:
+                // clang-format off
+                interpolate_2d_nearest_{{DTYPE}}(Y_buffer, X->shape + 2, X_buffer, Y->shape + 2, bases, steps,
+                                                  // clang-format on
+                                                  nearest_mode, loop_count);
 
-                        break;
-                    case LINEAR:
-                        interpolate_2d_linear_{{DTYPE}}(Y_buffer, X->shape + 2, X_buffer, Y->shape + 2, bases, steps, exclude_outside == 1, loop_count);
-                        break;
-                    case CUBIC:
-                        interpolate_2d_cubic_{{DTYPE}}(Y_buffer, X->shape + 2, X_buffer, Y->shape + 2, bases, steps, exclude_outside == 1, cubic_coeff_a, loop_count);
-                        break;
-                    default:
-                        assert(false); // Not possible
-                }
-           } 
                 break;
-        /*{% endfor %}*/
+            case LINEAR:
+                // clang-format off
+                interpolate_2d_linear_{{DTYPE}}(Y_buffer, X->shape + 2, X_buffer, Y->shape + 2, bases, steps,
+                                                 // clang-format on
+                                                 exclude_outside == 1, loop_count);
+                break;
+            case CUBIC:
+                // clang-format off
+                interpolate_2d_cubic_{{DTYPE}}(Y_buffer, X->shape + 2, X_buffer, Y->shape + 2, bases, steps,
+                                                // clang-format on
+                                                exclude_outside == 1, cubic_coeff_a, loop_count);
+                break;
             default:
-                connx_error("Not supported dtype: %d", X->dtype);
-                return CONNX_NOT_SUPPORTED_FEATURE;
+                assert(false); // Not possible
+            }
+        } break;
+            /*{% endfor %}*/
+        default:
+            connx_error("Not supported dtype: %d", X->dtype);
+            return CONNX_NOT_SUPPORTED_FEATURE;
         }
         break;
     default:

--- a/src/opset/Shape_15.c
+++ b/src/opset/Shape_15.c
@@ -18,9 +18,11 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
+// clang-format off
 int Shape_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-          __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-          __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                          // clang-format on
+                          __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                          __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
     connx_Tensor* data = connx_Graph_get(graph, inputs[0]);
 
     // end is optional, start is optional with default value from onnx-connx

--- a/src/opset/Sigmoid_13.c
+++ b/src/opset/Sigmoid_13.c
@@ -20,9 +20,12 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
+// clang-format off
 int Sigmoid_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-            __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-            __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                            // clang-format on
+                            __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                            __attribute__((unused)) uint32_t attribute_count,
+                            __attribute__((unused)) void** attributes) {
     connx_Tensor* X = connx_Graph_get(graph, inputs[0]);
     connx_Tensor* Y = connx_Tensor_alloc_like(X);
     if (Y == NULL) {

--- a/src/opset/Sign_13.c
+++ b/src/opset/Sign_13.c
@@ -18,9 +18,11 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
+// clang-format off
 int Sign_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-         __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-         __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                         // clang-format on
+                         __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                         __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
     connx_Tensor* X = connx_Graph_get(graph, inputs[0]);
     connx_Tensor* Y = connx_Tensor_alloc_like(X);
     if (Y == NULL) {

--- a/src/opset/Sin_7.c
+++ b/src/opset/Sin_7.c
@@ -20,9 +20,11 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
+// clang-format off
 int Sin_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-        __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-        __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                        // clang-format on
+                        __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                        __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
     connx_Tensor* X = connx_Graph_get(graph, inputs[0]);
     connx_Tensor* Y = connx_Tensor_alloc_like(X);
     if (Y == NULL) {

--- a/src/opset/Sinh_9.c
+++ b/src/opset/Sinh_9.c
@@ -20,9 +20,11 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
+// clang-format off
 int Sinh_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-         __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-         __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                         // clang-format on
+                         __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                         __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
     connx_Tensor* X = connx_Graph_get(graph, inputs[0]);
     connx_Tensor* Y = connx_Tensor_alloc_like(X);
     if (Y == NULL) {

--- a/src/opset/Slice_1.c
+++ b/src/opset/Slice_1.c
@@ -21,11 +21,13 @@
 #include <connx/connx.h>
 
 static int32_t get_input_index(const int32_t ndim, const int32_t* input_shape, const int32_t* output_shape,
-                        const int32_t* starts, const int32_t output_offset);
+                               const int32_t* starts, const int32_t output_offset);
 
+// clang-format off
 int Slice_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-          __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-          __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                          // clang-format on
+                          __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                          __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
     /*{% set supported_data_types = [
         INT8, INT16, INT32, INT64,
         UINT8, UINT16, UINT32, UINT64,
@@ -84,7 +86,8 @@ int Slice_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t ou
     connx_Graph_set(graph, outputs[0], output);
 
     // Get data type size
-    size_t data_type_size = connx_DataType_size(data->dtype);;
+    size_t data_type_size = connx_DataType_size(data->dtype);
+    ;
     int32_t total = connx_Int32_product(output_ndim, output_shape);
 
     // Somethimes, one of axis is 0, which means total is 0

--- a/src/opset/Slice_13.c
+++ b/src/opset/Slice_13.c
@@ -21,12 +21,14 @@
 #include <connx/connx.h>
 
 static int32_t get_input_index(const int32_t ndim, const int32_t* input_shape, const int32_t* output_shape,
-                        const int32_t* starts, __attribute__((unused)) const int32_t* steps,
-                        const int32_t output_offset);
+                               const int32_t* starts, __attribute__((unused)) const int32_t* steps,
+                               const int32_t output_offset);
 
+// clang-format off
 int Slice_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-          __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-          __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                          // clang-format on
+                          __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                          __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
     /*{% set supported_data_types = [
         INT8, INT16, INT32, INT64,
         UINT8, UINT16, UINT32, UINT64,

--- a/src/opset/Softplus_1.c
+++ b/src/opset/Softplus_1.c
@@ -20,9 +20,12 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
+// clang-format off
 int Softplus_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-             __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-             __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                             // clang-format on
+                             __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                             __attribute__((unused)) uint32_t attribute_count,
+                             __attribute__((unused)) void** attributes) {
     connx_Tensor* X = connx_Graph_get(graph, inputs[0]);
     connx_Tensor* Y = connx_Tensor_alloc_like(X);
     if (Y == NULL) {

--- a/src/opset/Split_13.c
+++ b/src/opset/Split_13.c
@@ -21,8 +21,10 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
-int Split_{{op_version}}(connx_Graph* graph, uint32_t output_count, uint32_t* outputs_, uint32_t input_count, uint32_t* inputs,
-          __attribute__((unused)) uint32_t attribute_count, void** attributes) {
+// clang-format off
+int Split_{{op_version}}(connx_Graph* graph, uint32_t output_count, uint32_t* outputs_, uint32_t input_count,
+                          // clang-format on
+                          uint32_t* inputs, __attribute__((unused)) uint32_t attribute_count, void** attributes) {
     /*{% set supported_data_types = [
         INT8, INT16, INT32, INT64,
         UINT8, UINT16, UINT32, UINT64,

--- a/src/opset/Squeeze_1.c
+++ b/src/opset/Squeeze_1.c
@@ -22,9 +22,11 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
+// clang-format off
 int Squeeze_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-        __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-        __attribute__((unused)) uint32_t attribute_count, void** attributes) {
+                            // clang-format on
+                            __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                            __attribute__((unused)) uint32_t attribute_count, void** attributes) {
     // Inputs
     const connx_Tensor* data = connx_Graph_get(graph, inputs[0]);
 
@@ -44,7 +46,8 @@ int Squeeze_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t 
             }
 
             if (axes_array[i] < 0 || axes_array[i] >= data->ndim || data->shape[axes_array[i]] != 1) {
-                connx_error("Squeeze: Invalid axes. %d is not a valid axis for %d-D tensor.", axes_array[i], data->ndim);
+                connx_error("Squeeze: Invalid axes. %d is not a valid axis for %d-D tensor.", axes_array[i],
+                            data->ndim);
                 return CONNX_TENSOR_SHAPE_NOT_MATCHING;
             }
         }

--- a/src/opset/Squeeze_13.c
+++ b/src/opset/Squeeze_13.c
@@ -22,9 +22,11 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
+// clang-format off
 int Squeeze_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-        uint32_t input_count, uint32_t* inputs,
-        __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                            // clang-format on
+                            uint32_t input_count, uint32_t* inputs, __attribute__((unused)) uint32_t attribute_count,
+                            __attribute__((unused)) void** attributes) {
     // Inputs
     const connx_Tensor* data = connx_Graph_get(graph, inputs[0]);
     const connx_Tensor* axes = input_count > 1 ? connx_Graph_get(graph, inputs[1]) : NULL;

--- a/src/opset/Tan_7.c
+++ b/src/opset/Tan_7.c
@@ -20,9 +20,11 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
+// clang-format off
 int Tan_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-        __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-        __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                        // clang-format on
+                        __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                        __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
     connx_Tensor* X = connx_Graph_get(graph, inputs[0]);
     connx_Tensor* Y = connx_Tensor_alloc_like(X);
     if (Y == NULL) {

--- a/src/opset/Tanh_13.c
+++ b/src/opset/Tanh_13.c
@@ -20,9 +20,11 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
+// clang-format off
 int Tanh_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-         __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-         __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                         // clang-format on
+                         __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                         __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
     connx_Tensor* X = connx_Graph_get(graph, inputs[0]);
     connx_Tensor* Y = connx_Tensor_alloc_like(X);
     if (Y == NULL) {

--- a/src/opset/Tile_13.c
+++ b/src/opset/Tile_13.c
@@ -35,9 +35,11 @@ static inline void get_indices(int32_t ndim, int32_t* shape, int32_t offset, int
 static void copy_input(void* output_buffer, void* input_buffer, int32_t ndim, int64_t* repeats_shape,
                        int32_t* input_shape, size_t type_size);
 
+// clang-format off
 int Tile_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-         __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-         __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                         // clang-format on
+                         __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                         __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
     /*{% set supported_dtypes = [
         UINT8, UINT16, UINT32, UINT64,
         INT8, INT16, INT32, INT64,

--- a/src/opset/Transpose_13.c
+++ b/src/opset/Transpose_13.c
@@ -20,12 +20,15 @@
 #include <connx/accel.h>
 #include <connx/connx.h>
 
-static int32_t get_output_index(const int32_t ndim, const int32_t* input_shape, const int32_t* output_shape, int32_t* perm,
-                         const int32_t input_index);
+static int32_t get_output_index(const int32_t ndim, const int32_t* input_shape, const int32_t* output_shape,
+                                int32_t* perm, const int32_t input_index);
 
+// clang-format off
 int Transpose_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-              __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-              __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+                              // clang-format on
+                              __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                              __attribute__((unused)) uint32_t attribute_count,
+                              __attribute__((unused)) void** attributes) {
     /*{% set supported_data_types = [
         INT8, INT16, INT32, INT64,
         UINT8, UINT16, UINT32, UINT64,

--- a/src/opset/__Binary.jinja.c
+++ b/src/opset/__Binary.jinja.c
@@ -26,9 +26,11 @@
 static int32_t get_broadcasted_input_offset(const connx_Tensor* output, const connx_Tensor* input,
                                             int32_t output_offset);
 
-int {{fname}}_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-              __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-              __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+// clang-format off
+int {{ fname }}_{{ op_version }}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
+                 // clang-format on
+                 __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                 __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
     // Inputs
     connx_Tensor* A = connx_Graph_get(graph, inputs[0]);
     connx_Tensor* B = connx_Graph_get(graph, inputs[1]);

--- a/src/opset/__Compare.jinja.c
+++ b/src/opset/__Compare.jinja.c
@@ -26,9 +26,11 @@
 static int32_t get_broadcasted_input_offset(const connx_Tensor* output, const connx_Tensor* input,
                                             int32_t output_offset);
 
-int {{fname}}_{{op_version}}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
-              __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-              __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+// clang-format off
+int {{ fname }}_{{ op_version }}(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, uint32_t* outputs,
+                 // clang-format on
+                 __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+                 __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
     // Inputs
     connx_Tensor* A = connx_Graph_get(graph, inputs[0]);
     connx_Tensor* B = connx_Graph_get(graph, inputs[1]);

--- a/src/opset/_ref_0.c
+++ b/src/opset/_ref_0.c
@@ -18,8 +18,8 @@
 #include <connx/connx.h>
 
 int _ref_0(connx_Graph* graph, __attribute__((unused)) uint32_t output_count, __attribute__((unused)) uint32_t* outputs,
-         __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
-         __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
+           __attribute__((unused)) uint32_t input_count, uint32_t* inputs,
+           __attribute__((unused)) uint32_t attribute_count, __attribute__((unused)) void** attributes) {
 
     connx_Tensor* tensor = connx_Graph_get(graph, inputs[0]);
     int32_t ref_count = *(int32_t*)attributes[0];


### PR DESCRIPTION
* Change semihlab/connx|onnx-connx to tsnlab/* (on CI, README)
* Remove `TEMPLATE_*` template engine (it also caused a few bugs. so fixed it)
* Apply clang-format
* Skip pytest job `test_identity_opt_*`. This takes 6h+ on Github ci

## Improvment

Now support `#line` preprocessor for jinja templates (which imported from another jinja template) for easy debugging