### PR TITLE
Remove connx_read/write from hal

### DIFF
--- a/include/connx/hal.h
+++ b/include/connx/hal.h
@@ -61,6 +61,8 @@ void connx_Thread_run_all(void* (*run)(void*), int32_t count, void* contexts, in
 
 // debugging message
 struct _connx_Tensor;
+struct _connx_Graph;
+struct _connx_Node;
 void connx_debug(const char* format, ...);
 void connx_info(const char* format, ...);
 void connx_error(const char* format, ...);
@@ -68,6 +70,8 @@ void connx_error(const char* format, ...);
 void connx_Iterator_dump(int32_t* iterator);
 void connx_Tensor_dump(struct _connx_Tensor* tensor);
 void connx_Tensor_dump_header(struct _connx_Tensor* tensor);
+
+void connx_dump_node_outputs(struct _connx_Graph* graph, struct _connx_Node* node);
 
 uint64_t connx_time();
 void connx_watch_start(int32_t idx);

--- a/include/connx/hal.h
+++ b/include/connx/hal.h
@@ -37,9 +37,13 @@ void connx_destroy();
 void* connx_alloc(uint32_t size);
 void connx_free(void* ptr);
 
-// Model loader
-void* connx_load(const char* name);
-void connx_unload(void* buf);
+// Loaders
+void* connx_load_model();
+void connx_unload_model(void* buf);
+void* connx_load_data(uint32_t graph_id, uint32_t id);
+void connx_unload_data(void* buf);
+void* connx_load_text(uint32_t graph_id);
+void connx_unload_text(void* buf);
 
 // Lock
 #ifdef __linux__

--- a/include/connx/hal.h
+++ b/include/connx/hal.h
@@ -41,10 +41,6 @@ void connx_free(void* ptr);
 void* connx_load(const char* name);
 void connx_unload(void* buf);
 
-// Tensor I/O
-int32_t connx_read(void* buf, int32_t size);
-int32_t connx_write(void* buf, int32_t size);
-
 // Lock
 #ifdef __linux__
 typedef pthread_mutex_t connx_Lock;

--- a/include/connx/hal_common.h
+++ b/include/connx/hal_common.h
@@ -15,8 +15,8 @@
  *  You should have received a copy of the GNU General Public License
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-#ifndef __CONNX_HAL_H__
-#define __CONNX_HAL_H__
+#ifndef __CONNX_HAL_COMMON_H__
+#define __CONNX_HAL_COMMON_H__
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -78,4 +78,4 @@ void connx_watch_start(int32_t idx);
 void connx_watch_stop(int32_t idx);
 void connx_watch_dump();
 
-#endif /* __CONNX_HAL_H__ */
+#endif /* __CONNX_HAL_COMMON_H__ */

--- a/ports/esp32/main/hal.c
+++ b/ports/esp32/main/hal.c
@@ -126,15 +126,6 @@ void connx_unload(__attribute__((unused)) void* buf) {
     free(buf);
 }
 
-// Tensor I/O
-int32_t connx_read(void* buf, int32_t size) {
-    return -1;
-}
-
-int32_t connx_write(void* buf, int32_t size) {
-    return -1;
-}
-
 // Lock
 void connx_Lock_init(connx_Lock* lock) {
     pthread_mutex_init(lock, NULL);

--- a/ports/linux/CMakeLists.txt
+++ b/ports/linux/CMakeLists.txt
@@ -56,6 +56,7 @@ endif()
 add_executable(${PROJECT_NAME} ${SRC})
 
 target_include_directories(${PROJECT_NAME} PUBLIC ${CONNX_HOME}/include)
+target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Werror -std=c99)
 target_link_libraries(${PROJECT_NAME} m pthread)
 

--- a/ports/linux/include/connx/hal.h
+++ b/ports/linux/include/connx/hal.h
@@ -6,10 +6,5 @@
 #include <connx/hal_common.h>
 
 int hal_set_model(const char* path);
-int hal_set_tensorin(const char* path);
-int hal_set_tensorout(const char* path);
-int32_t hal_read(void* buf, int32_t size);
-int32_t hal_write(void* buf, int32_t size);
-
 
 #endif // __CONNX_HAL_H__

--- a/ports/linux/include/connx/hal.h
+++ b/ports/linux/include/connx/hal.h
@@ -1,0 +1,15 @@
+#ifndef __CONNX_HAL_H__
+#define __CONNX_HAL_H__
+
+#include <stdint.h>
+
+#include <connx/hal_common.h>
+
+int hal_set_model(const char* path);
+int hal_set_tensorin(const char* path);
+int hal_set_tensorout(const char* path);
+int32_t hal_read(void* buf, int32_t size);
+int32_t hal_write(void* buf, int32_t size);
+
+
+#endif // __CONNX_HAL_H__

--- a/ports/linux/src/hal.c
+++ b/ports/linux/src/hal.c
@@ -167,7 +167,7 @@ void connx_free(void* ptr) {
 }
 
 // Model loader
-int connx_set_model(const char* path) {
+int hal_set_model(const char* path) {
     snprintf(_model_path, 128, "%s", path);
     struct stat st;
     if (stat(_model_path, &st) == 0 && S_ISDIR(st.st_mode)) {

--- a/ports/linux/src/hal.c
+++ b/ports/linux/src/hal.c
@@ -208,7 +208,7 @@ int hal_set_tensorout(const char* path) {
     }
 }
 
-void* connx_load(const char* name) {
+void* _load(const char* name) {
     char path[256];
     snprintf(path, 256, "%s/%s", _model_path, name);
 
@@ -249,8 +249,37 @@ void* connx_load(const char* name) {
     return buf;
 }
 
-void connx_unload(__attribute__((unused)) void* buf) {
+
+void* connx_load_model() {
+    return _load("model.connx");
+}
+
+void* connx_load_data(uint32_t graph_id, uint32_t id) {
+    char name[16];
+    snprintf(name, 16, "%u_%u.data", graph_id, id);
+    return _load(name);
+}
+
+void* connx_load_text(uint32_t graph_id) {
+    char name[256];
+    snprintf(name, 256, "%u.text", graph_id);
+    return _load(name);
+}
+
+static inline void _unload(void* buf) {
     free(buf);
+}
+
+void connx_unload_model(void* buf) {
+    _unload(buf);
+}
+
+void connx_unload_data(void* buf) {
+    _unload(buf);
+}
+
+void connx_unload_text(void* buf) {
+    _unload(buf);
 }
 
 // Tensor I/O

--- a/ports/linux/src/hal.c
+++ b/ports/linux/src/hal.c
@@ -166,7 +166,7 @@ int connx_set_model(const char* path) {
     }
 }
 
-int connx_set_tensorin(const char* path) {
+int hal_set_tensorin(const char* path) {
     if (path == NULL && _tensorin != NULL) {
         fclose(_tensorin);
         _tensorin = NULL;
@@ -187,7 +187,7 @@ int connx_set_tensorin(const char* path) {
     }
 }
 
-int connx_set_tensorout(const char* path) {
+int hal_set_tensorout(const char* path) {
     if (path == NULL && _tensorout != NULL) {
         fclose(_tensorout);
         _tensorout = NULL;
@@ -254,7 +254,7 @@ void connx_unload(__attribute__((unused)) void* buf) {
 }
 
 // Tensor I/O
-int32_t connx_read(void* buf, int32_t size) {
+int32_t hal_read(void* buf, int32_t size) {
     FILE* file = _tensorin != NULL ? _tensorin : stdin;
 
     void* p = buf;
@@ -274,7 +274,7 @@ int32_t connx_read(void* buf, int32_t size) {
     return size;
 }
 
-int32_t connx_write(void* buf, int32_t size) {
+int32_t hal_write(void* buf, int32_t size) {
     FILE* file = _tensorout != NULL ? _tensorout : stdout;
 
     void* p = buf;

--- a/ports/linux/src/main.c
+++ b/ports/linux/src/main.c
@@ -25,13 +25,7 @@
 #include <sys/stat.h>
 
 #include <connx/connx.h>
-
-// HAL API from hal.c
-int connx_set_model(const char* path);
-int hal_set_tensorin(const char* path);
-int hal_set_tensorout(const char* path);
-int32_t hal_read(void* buf, int32_t size);
-int32_t hal_write(void* buf, int32_t size);
+#include <connx/hal.h>
 
 static int read_tensor(connx_Tensor** tensor) {
     int32_t dtype;
@@ -344,7 +338,7 @@ int main(int argc, char** argv) {
     }
 
     // Load connx model
-    ret = connx_set_model(argv[1]);
+    ret = hal_set_model(argv[1]);
     if (ret != 0) {
         goto done;
     }

--- a/ports/linux/src/main.c
+++ b/ports/linux/src/main.c
@@ -27,23 +27,84 @@
 #include <connx/connx.h>
 #include <connx/hal.h>
 
-static int read_tensor(connx_Tensor** tensor) {
+static FILE* open_tensorin(const char* path) {
+    if (strncmp("-", path, 2) == 0) {
+        return stdin;
+    } else {
+        return fopen(path, "r");
+    }
+}
+
+static FILE* open_tensorout(const char* path) {
+    if (strncmp("-", path, 2) == 0) {
+        return stdout;
+    } else {
+        return fopen(path, "w");
+    }
+}
+
+static int close_tensor(FILE* fp) {
+    if (fp == stdin || fp == stdout) {
+        return 0;
+    }
+
+    return fclose(fp);
+}
+
+static int32_t file_read(FILE* fp, void* buf, int32_t size) {
+    void* p = buf;
+    size_t remain = size;
+    while (remain > 0) {
+        int len = fread(p, 1, remain, fp);
+
+        if (len < 0) {
+            fprintf(stderr, "HAL ERROR: Cannot read input data");
+            return -1;
+        }
+
+        p += len;
+        remain -= len;
+    }
+
+    return size;
+}
+
+static int32_t file_write(FILE* fp, void* buf, int32_t size) {
+    void* p = buf;
+    size_t remain = size;
+    while (remain > 0) {
+        int len = fwrite(p, 1, remain, fp);
+        if (len < 0) {
+            fprintf(stderr, "HAL ERROR: Cannot read input data");
+            return -1;
+        }
+
+        p += len;
+        remain -= len;
+    }
+
+    fflush(fp);
+
+    return size;
+}
+
+static int read_tensor(FILE* fp, connx_Tensor** tensor) {
     int32_t dtype;
-    if (hal_read(&dtype, sizeof(int32_t)) != (int32_t)sizeof(int32_t)) {
+    if (file_read(fp, &dtype, sizeof(int32_t)) != (int32_t)sizeof(int32_t)) {
         connx_error("Cannot read input data type from Tensor I/O module.\n");
 
         return CONNX_IO_ERROR;
     }
 
     int32_t ndim;
-    if (hal_read(&ndim, sizeof(int32_t)) != (int32_t)sizeof(int32_t)) {
+    if (file_read(fp, &ndim, sizeof(int32_t)) != (int32_t)sizeof(int32_t)) {
         connx_error("Cannot read input ndim from Tensor I/O module.\n");
 
         return CONNX_IO_ERROR;
     }
 
     int32_t shape[ndim];
-    if (hal_read(&shape, sizeof(int32_t) * ndim) != (int32_t)(sizeof(int32_t) * ndim)) {
+    if (file_read(fp, &shape, sizeof(int32_t) * ndim) != (int32_t)(sizeof(int32_t) * ndim)) {
         connx_error("Cannot read input shape from Tensor I/O module.\n");
 
         return CONNX_IO_ERROR;
@@ -56,7 +117,7 @@ static int read_tensor(connx_Tensor** tensor) {
         return CONNX_NOT_ENOUGH_MEMORY;
     }
 
-    int32_t len = hal_read((*tensor)->buffer, (*tensor)->size);
+    int32_t len = file_read(fp, (*tensor)->buffer, (*tensor)->size);
     if (len != (int32_t)(*tensor)->size) {
         connx_error("Cannot read input data from Tensor I/O moudle.\n");
 
@@ -66,42 +127,42 @@ static int read_tensor(connx_Tensor** tensor) {
     return CONNX_OK;
 }
 
-static int write_tensor(connx_Tensor* tensor) {
+static int write_tensor(FILE* fp, connx_Tensor* tensor) {
     int ret;
 
     int32_t dtype = tensor->dtype;
-    if (hal_write(&dtype, sizeof(int32_t)) != (int32_t)sizeof(int32_t)) {
+    if (file_write(fp, &dtype, sizeof(int32_t)) != (int32_t)sizeof(int32_t)) {
         connx_error("Cannot write tensor data type to Tensor I/O module.\n");
 
         ret = -CONNX_IO_ERROR;
-        hal_write(&ret, sizeof(int32_t));
+        file_write(fp, &ret, sizeof(int32_t));
 
         return CONNX_IO_ERROR;
     }
 
-    if (hal_write(&tensor->ndim, sizeof(int32_t)) != (int32_t)sizeof(int32_t)) {
+    if (file_write(fp, &tensor->ndim, sizeof(int32_t)) != (int32_t)sizeof(int32_t)) {
         connx_error("Cannot write tensor ndim to Tensor I/O module.\n");
 
         ret = -CONNX_IO_ERROR;
-        hal_write(&ret, sizeof(int32_t));
+        file_write(fp, &ret, sizeof(int32_t));
 
         return CONNX_IO_ERROR;
     }
 
-    if (hal_write(tensor->shape, sizeof(int32_t) * tensor->ndim) != (int32_t)(sizeof(int32_t) * tensor->ndim)) {
+    if (file_write(fp, tensor->shape, sizeof(int32_t) * tensor->ndim) != (int32_t)(sizeof(int32_t) * tensor->ndim)) {
         connx_error("Cannot write tensor shape to Tensor I/O module.\n");
 
         ret = -CONNX_IO_ERROR;
-        hal_write(&ret, sizeof(int32_t));
+        file_write(fp, &ret, sizeof(int32_t));
 
         return CONNX_IO_ERROR;
     }
 
-    if (hal_write(tensor->buffer, tensor->size) != (int32_t)tensor->size) {
+    if (file_write(fp, tensor->buffer, tensor->size) != (int32_t)tensor->size) {
         connx_error("Cannot write tensor data to Tensor I/O module.\n");
 
         ret = -CONNX_IO_ERROR;
-        hal_write(&ret, sizeof(int32_t));
+        file_write(fp, &ret, sizeof(int32_t));
 
         return CONNX_IO_ERROR;
     }
@@ -112,14 +173,18 @@ static int write_tensor(connx_Tensor* tensor) {
 static int run_from_fifo(connx_Model* model, char* tensorin, char* tensorout) {
     int ret;
 
-    ret = hal_set_tensorin(tensorin);
-    if (ret != 0) {
-        return ret;
+    FILE* fp_in = open_tensorin(tensorin);
+    if (fp_in == NULL) {
+        return CONNX_RESOURCE_NOT_FOUND;
     }
 
-    ret = hal_set_tensorout(tensorout);
-    if (ret != 0) {
-        return ret;
+    FILE* fp_out = open_tensorout(tensorout);
+    if (fp_out == NULL) {
+        return CONNX_RESOURCE_NOT_FOUND;
+
+        if (fp_in != NULL && fp_in != stdin) {
+            close_tensor(fp_in);
+        }
     }
 
     // loop: input -> inference -> output
@@ -127,11 +192,11 @@ static int run_from_fifo(connx_Model* model, char* tensorin, char* tensorout) {
     while (true) {
         // Read input count from HAL
         uint32_t input_count;
-        if (hal_read(&input_count, sizeof(uint32_t)) != (int32_t)sizeof(uint32_t)) {
+        if (file_read(fp_in, &input_count, sizeof(uint32_t)) != (int32_t)sizeof(uint32_t)) {
             connx_error("Cannot read input count from Tensor I/O module.\n");
 
             ret = -CONNX_IO_ERROR;
-            hal_write(&ret, sizeof(int32_t));
+            file_write(fp_out, &ret, sizeof(int32_t));
 
             return CONNX_IO_ERROR;
         }
@@ -144,11 +209,11 @@ static int run_from_fifo(connx_Model* model, char* tensorin, char* tensorout) {
         connx_Tensor* inputs[input_count];
         for (uint32_t i = 0; i < input_count; i++) {
             connx_Tensor* tensor;
-            ret = read_tensor(&tensor);
+            ret = read_tensor(fp_in, &tensor);
 
             if (ret != CONNX_OK) {
                 int code = -ret;
-                hal_write(&code, sizeof(int32_t));
+                file_write(fp_out, &code, sizeof(int32_t));
 
                 return ret;
             }
@@ -163,28 +228,28 @@ static int run_from_fifo(connx_Model* model, char* tensorin, char* tensorout) {
         ret = connx_Model_run(model, input_count, inputs, &output_count, outputs);
         if (ret != CONNX_OK) {
             int32_t ret2 = -ret;
-            hal_write(&ret2, sizeof(int32_t));
+            file_write(fp_out, &ret2, sizeof(int32_t));
 
             return ret;
         }
 
         // Write outputs
         // Write output count
-        if (hal_write(&output_count, sizeof(uint32_t)) != (int32_t)sizeof(uint32_t)) {
+        if (file_write(fp_out, &output_count, sizeof(uint32_t)) != (int32_t)sizeof(uint32_t)) {
             connx_error("Cannot write output data to Tensor I/O moudle.\n");
 
             ret = -CONNX_IO_ERROR;
-            hal_write(&ret, sizeof(int32_t));
+            file_write(fp_out, &ret, sizeof(int32_t));
 
             return CONNX_IO_ERROR;
         }
 
         for (uint32_t i = 0; i < output_count; i++) {
-            ret = write_tensor(outputs[i]);
+            ret = write_tensor(fp_out, outputs[i]);
 
             if (ret != CONNX_OK) {
                 int code = -ret;
-                hal_write(&code, sizeof(int32_t));
+                file_write(fp_out, &code, sizeof(int32_t));
 
                 return ret;
             }
@@ -202,6 +267,9 @@ static int run_from_fifo(connx_Model* model, char* tensorin, char* tensorout) {
         }
     }
 
+    close_tensor(fp_in);
+    close_tensor(fp_out);
+
     return CONNX_OK;
 }
 
@@ -213,13 +281,13 @@ static int run_from_file(connx_Model* model, int input_count, char** input_files
 
     for (int i = 0; i < input_count; i++) {
         // Open file
-        ret = hal_set_tensorin(input_files[i]);
-        if (ret != CONNX_OK) {
-            return ret;
+        FILE* tensorin = open_tensorin(input_files[i]);
+        if (tensorin == NULL) {
+            return CONNX_RESOURCE_NOT_FOUND;
         }
 
         connx_Tensor* tensor;
-        ret = read_tensor(&tensor);
+        ret = read_tensor(tensorin, &tensor);
 
         if (ret != CONNX_OK) {
             connx_error("Cannot read tensor: %s\n", input_files[i]);
@@ -229,7 +297,7 @@ static int run_from_file(connx_Model* model, int input_count, char** input_files
         inputs[i] = tensor;
 
         // Close file
-        hal_set_tensorin(NULL);
+        close_tensor(tensorin);
     }
 
     // Run model

--- a/src/connx.c
+++ b/src/connx.c
@@ -24,7 +24,7 @@
 
 #include <connx/accel.h>
 #include <connx/connx.h>
-#include <connx/hal.h>
+#include <connx/hal_common.h>
 #include <connx/opset.h>
 
 #include "ver.h"

--- a/src/connx.c
+++ b/src/connx.c
@@ -167,9 +167,9 @@ static int parse_Model(connx_Model* model, char* metadata) {
 
 int connx_Model_init(connx_Model* model) {
     // Parse model
-    void* metadata = connx_load("model.connx");
+    void* metadata = connx_load_model();
     int ret = parse_Model(model, metadata);
-    connx_unload(metadata);
+    connx_unload_model(metadata);
 
     if (ret != CONNX_OK) {
         return ret;
@@ -233,10 +233,7 @@ int connx_Model_run(connx_Model* model, uint32_t input_count, connx_Tensor** inp
 }
 
 static int parse_initializer(connx_Tensor** tensor, uint32_t graph_id, uint32_t initializer_id) {
-    char name[16];
-    snprintf(name, 16, "%u_%u.data", graph_id, initializer_id);
-
-    void* buf = connx_load(name);
+    void* buf = connx_load_data(graph_id, initializer_id);
     if (buf == NULL) {
         return CONNX_RESOURCE_NOT_FOUND;
     }
@@ -246,7 +243,7 @@ static int parse_initializer(connx_Tensor** tensor, uint32_t graph_id, uint32_t 
         return CONNX_NOT_ENOUGH_MEMORY;
     }
 
-    connx_unload(buf);
+    connx_unload_data(buf);
 
     return CONNX_OK;
 }
@@ -513,12 +510,9 @@ int connx_Graph_init(connx_Graph* graph, connx_Model* model, uint32_t graph_id) 
     graph->id = graph_id;
 
     // Parse value_info
-    char name[256];
-    snprintf(name, 256, "%u.text", graph_id);
-
-    void* text = connx_load(name);
+    void* text = connx_load_text(graph_id);
     int ret = parse_Graph(graph, text);
-    connx_unload(text);
+    connx_unload_text(text);
 
     if (ret != CONNX_OK) {
         return ret;

--- a/src/tensor.c
+++ b/src/tensor.c
@@ -21,7 +21,7 @@
 #include <string.h> // memcpy
 
 #include <connx/accel.h>
-#include <connx/hal.h>
+#include <connx/hal_common.h>
 #include <connx/tensor.h>
 
 uint32_t connx_DataType_size(connx_DataType dtype) {


### PR DESCRIPTION
read/write operation is platform dependant.
So remove it from common hal.h, And implement or not on platform dependent codes.

- [x] Rename already used platform dependant functions with `connx_` prefix to `hal_` prefix
- [x] Get rid of linux specific codes from common(tensor|connx.c) code
  - [x] Move debug dump of node outputs
  - [x] Split connx_{load,unload} function into 3 different set and move hard-coded filename template into hal.c
- [x] Move hal.h into hal_common and create ports/linux/include/connx/hal.h
  - [x] Update cmake+gen.sh to handle newer files correctly