### PR TITLE
Optimise binary operators

### DIFF
--- a/include/connx/tensor.h
+++ b/include/connx/tensor.h
@@ -110,6 +110,16 @@ connx_Tensor* connx_Tensor_alloc_like(connx_Tensor* tensor);
 connx_Tensor* connx_Tensor_alloc_buffer(void* buf);
 
 /**
+ * @brief Check if the output tensor uses broadcasted offset
+ *
+ * @param A Input tensor A
+ * @param B Input tensor B
+ * @return true if the output tensor need to use broadcasted offset
+ * @return false if the output tensor does not need to use broadcasted offset
+ */
+bool should_broadcast(connx_Tensor* A, connx_Tensor* B);
+
+/**
  * Create broadcasted tensor
  *
  * @param dtype output tensor's data type

--- a/include/connx/tensor.h
+++ b/include/connx/tensor.h
@@ -117,7 +117,7 @@ connx_Tensor* connx_Tensor_alloc_buffer(void* buf);
  * @return true if the output tensor need to use broadcasted offset
  * @return false if the output tensor does not need to use broadcasted offset
  */
-bool should_broadcast(connx_Tensor* A, connx_Tensor* B);
+bool connx_Tensor_should_broadcast(connx_Tensor* A, connx_Tensor* B);
 
 /**
  * Create broadcasted tensor
@@ -128,6 +128,19 @@ bool should_broadcast(connx_Tensor* A, connx_Tensor* B);
  * @return newly allocated tensor. NULL if cannot be broadcasted.
  */
 connx_Tensor* connx_Tensor_alloc_broadcasted(const connx_DataType dtype, connx_Tensor* A, connx_Tensor* B);
+
+/**
+ * @brief Get the broadcasted input offset object
+ * @see connx_Tensor_alloc_broadcasted
+ *
+ * @param output Output tensor that has broadcasted dimension
+ * @param input Input tensor to calculate the offset
+ * @param output_offset Offset to use on output tensor
+ * @return int32_t offset to use for input tensor
+ */
+int32_t connx_Tensor_get_broadcasted_input_offset(const connx_Tensor* output, const connx_Tensor* input,
+                                                  int32_t output_offset);
+
 connx_Tensor* connx_Tensor_copy(connx_Tensor* tensor);
 connx_Tensor* connx_Tensor_reshape(connx_Tensor* tensor, int32_t ndim, int32_t* shape);
 

--- a/include/connx/tensor.h
+++ b/include/connx/tensor.h
@@ -110,14 +110,16 @@ connx_Tensor* connx_Tensor_alloc_like(connx_Tensor* tensor);
 connx_Tensor* connx_Tensor_alloc_buffer(void* buf);
 
 /**
- * @brief Check if the output tensor uses broadcasted offset
+ * @brief Check if two tensor have same shape or one have prepended 1s
+ * Example: [4, 7, 2] and [4, 7, 2] are same shape while [1, 2, 3] and [4, 7, 2] are not
+ * [4, 7, 2] and [1, 4, 7, 2] are also same shape because [1] is prepended and same in array
+ * But [4, 7, 2] and [2, 4, 7, 2] are not same shape
  *
  * @param A Input tensor A
  * @param B Input tensor B
- * @return true if the output tensor need to use broadcasted offset
- * @return false if the output tensor does not need to use broadcasted offset
+ * @return true if two tensor have same shape or one have prepended 1s, or false
  */
-bool connx_Tensor_should_broadcast(connx_Tensor* A, connx_Tensor* B);
+bool connx_Tensor_is_likely_same_shape(connx_Tensor* A, connx_Tensor* B);
 
 /**
  * Create broadcasted tensor

--- a/src/opset/__Binary.jinja.c
+++ b/src/opset/__Binary.jinja.c
@@ -70,12 +70,20 @@ int {{ fname }}_{{ op_version }}(connx_Graph* graph, __attribute__((unused)) uin
         {{TYPE}}* B_array = B->buffer;
         {{TYPE}}* C_array = C->buffer;
 
-        for (int32_t i = 0; i < total; i++) {
-            int32_t input_offset_a = get_broadcasted_input_offset(C, A, i);
-            int32_t input_offset_b = get_broadcasted_input_offset(C, B, i);
-            // clang-format off
-            C_array[i] = A_array[input_offset_a] {{operator}} B_array[input_offset_b];
-            // clang-format on
+        if (should_broadcast(A, B)) {
+            for (int32_t i = 0; i < total; i++) {
+                int32_t input_offset_a = get_broadcasted_input_offset(C, A, i);
+                int32_t input_offset_b = get_broadcasted_input_offset(C, B, i);
+                // clang-format off
+                C_array[i] = A_array[input_offset_a] {{operator}} B_array[input_offset_b];
+                // clang-format on
+            }
+        } else {
+            for (int32_t i = 0; i < total; i++) {
+                // clang-format off
+                C_array[i] = A_array[i] {{operator}} B_array[i];
+                // clang-format on
+            }
         }
     } break;
         /*{% endfor %}*/

--- a/src/opset/__Binary.jinja.c
+++ b/src/opset/__Binary.jinja.c
@@ -67,18 +67,18 @@ int {{ fname }}_{{ op_version }}(connx_Graph* graph, __attribute__((unused)) uin
         {{TYPE}}* B_array = B->buffer;
         {{TYPE}}* C_array = C->buffer;
 
-        if (connx_Tensor_should_broadcast(A, B)) {
+        if (connx_Tensor_is_likely_same_shape(A, B)) {
+            for (int32_t i = 0; i < total; i++) {
+                // clang-format off
+                C_array[i] = A_array[i] {{operator}} B_array[i];
+                // clang-format on
+            }
+        } else {
             for (int32_t i = 0; i < total; i++) {
                 int32_t input_offset_a = connx_Tensor_get_broadcasted_input_offset(C, A, i);
                 int32_t input_offset_b = connx_Tensor_get_broadcasted_input_offset(C, B, i);
                 // clang-format off
                 C_array[i] = A_array[input_offset_a] {{operator}} B_array[input_offset_b];
-                // clang-format on
-            }
-        } else {
-            for (int32_t i = 0; i < total; i++) {
-                // clang-format off
-                C_array[i] = A_array[i] {{operator}} B_array[i];
                 // clang-format on
             }
         }

--- a/src/tensor.c
+++ b/src/tensor.c
@@ -210,28 +210,26 @@ connx_Tensor* connx_Tensor_alloc_buffer(void* buf) {
 }
 
 bool connx_Tensor_should_broadcast(connx_Tensor* A, connx_Tensor* B) {
-    int32_t pad_a;
-    int32_t pad_b;
     int32_t ndim_big = A->ndim > B->ndim ? A->ndim : B->ndim;
     int32_t ndim_small = A->ndim < B->ndim ? A->ndim : B->ndim;
 
-    pad_a = ndim_big - A->ndim;
-    pad_b = ndim_big - B->ndim;
+    int32_t pad_a = ndim_big - A->ndim;
+    int32_t pad_b = ndim_big - B->ndim;
 
     // Prepended dimensions must be 1, 1, 1
-    for (int i = 0; i < pad_a; i += 1) {
+    for (int32_t i = 0; i < pad_a; i += 1) {
         if (A->shape[i] != 1) {
             return true;
         }
     }
-    for (int i = 0; i < pad_b; i += 1) {
+    for (int32_t i = 0; i < pad_b; i += 1) {
         if (B->shape[i] != 1) {
             return true;
         }
     }
 
     // All the rest dimensions must be equal
-    for (int i = 0; i < ndim_small; i += 1) {
+    for (int32_t i = 0; i < ndim_small; i += 1) {
         if (A->shape[i + pad_a] != B->shape[i + pad_b]) {
             return true;
         }

--- a/src/tensor.c
+++ b/src/tensor.c
@@ -208,6 +208,37 @@ connx_Tensor* connx_Tensor_alloc_buffer(void* buf) {
     return tensor;
 }
 
+bool should_broadcast(connx_Tensor* A, connx_Tensor* B) {
+    int32_t pad_a;
+    int32_t pad_b;
+    int32_t ndim_big = A->ndim > B->ndim ? A->ndim : B->ndim;
+    int32_t ndim_small = A->ndim < B->ndim ? A->ndim : B->ndim;
+
+    pad_a = ndim_big - A->ndim;
+    pad_b = ndim_big - B->ndim;
+
+    // Prepended dimensions must be 1, 1, 1
+    for (int i = 0; i < pad_a; i += 1) {
+        if (A->shape[i] != 1) {
+            return true;
+        }
+    }
+    for (int i = 0; i < pad_b; i += 1) {
+        if (B->shape[i] != 1) {
+            return true;
+        }
+    }
+
+    // All the rest dimensions must be equal
+    for (int i = 0; i < ndim_small; i += 1) {
+        if (A->shape[i + pad_a] != B->shape[i + pad_b]) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 connx_Tensor* connx_Tensor_alloc_broadcasted(const connx_DataType dtype, connx_Tensor* A, connx_Tensor* B) {
     int32_t ndim = (A->ndim > B->ndim) ? A->ndim : B->ndim;
     int32_t shape[ndim];

--- a/src/tensor.c
+++ b/src/tensor.c
@@ -209,7 +209,7 @@ connx_Tensor* connx_Tensor_alloc_buffer(void* buf) {
     return tensor;
 }
 
-bool connx_Tensor_should_broadcast(connx_Tensor* A, connx_Tensor* B) {
+bool connx_Tensor_is_likely_same_shape(connx_Tensor* A, connx_Tensor* B) {
     int32_t ndim_big = A->ndim > B->ndim ? A->ndim : B->ndim;
     int32_t ndim_small = A->ndim < B->ndim ? A->ndim : B->ndim;
 
@@ -219,23 +219,23 @@ bool connx_Tensor_should_broadcast(connx_Tensor* A, connx_Tensor* B) {
     // Prepended dimensions must be 1, 1, 1
     for (int32_t i = 0; i < pad_a; i += 1) {
         if (A->shape[i] != 1) {
-            return true;
+            return false;
         }
     }
     for (int32_t i = 0; i < pad_b; i += 1) {
         if (B->shape[i] != 1) {
-            return true;
+            return false;
         }
     }
 
     // All the rest dimensions must be equal
     for (int32_t i = 0; i < ndim_small; i += 1) {
         if (A->shape[i + pad_a] != B->shape[i + pad_b]) {
-            return true;
+            return false;
         }
     }
 
-    return false;
+    return true;
 }
 
 connx_Tensor* connx_Tensor_alloc_broadcasted(const connx_DataType dtype, connx_Tensor* A, connx_Tensor* B) {


### PR DESCRIPTION
Check if needed to use broadcasted offset, If not, use faster way

Comparison between this pr (Blue is before, Red is after this PR)
![image](https://user-images.githubusercontent.com/5047683/160520662-533350ee-7ce0-4ecd-8e6d-53b6554334c7.png)

This pr also moves common function (that would duplicated on gen.sh) from __Binary.jinja.c to tensor.c
This reduces compiled binary size about 10kB (583kB → 574kB)