### PR TITLE
Improve python performance

### DIFF
--- a/pyconnx/connx/__init__.py
+++ b/pyconnx/connx/__init__.py
@@ -191,13 +191,15 @@ class Model(Wrapper):
             bindings.tensor_ref_child(t._wrapped_object)
 
         def func():
-
             bindings.model_run(
                 self._wrapped_object,
                 input_count,
                 inputs,
                 ctypes.byref(output_count),
                 outputs)
+
+            for i in range(output_count.value):
+                bindings.tensor_unref(outputs[i].contents)
 
         if aggregate:
             result = timeit.timeit(func, number=repeat) / repeat

--- a/pyconnx/connx/__init__.py
+++ b/pyconnx/connx/__init__.py
@@ -1,7 +1,8 @@
 import ctypes
 import math
+import statistics
 import struct
-import timeit
+import time
 
 from threading import Lock
 from typing import List, Optional, Union
@@ -186,33 +187,38 @@ class Model(Wrapper):
         outputs = (ctypes.POINTER(Tensor._wrapped_class_) * output_count.value)()
 
         for t in input_data:
-            # XXX: Don't know why, but it's unreferenced twice
+            # To avoid unwanted free, use child_count
             bindings.tensor_ref_child(t._wrapped_object)
 
-        def func():
+        results = []
+
+        for _ in range(repeat):
+            start = time.time()
             bindings.model_run(
                 self._wrapped_object,
                 input_count,
                 inputs,
                 ctypes.byref(output_count),
                 outputs)
+            end = time.time()
+            results.append(end - start)
+            # [Tensor(outputs[i].contents) for i in range(output_count.value)]
 
             for i in range(output_count.value):
                 bindings.tensor_unref(outputs[i].contents)
-
-        if aggregate:
-            result = timeit.timeit(func, number=repeat) / repeat
-        else:
-            result = timeit.repeat(func, repeat=repeat, number=1)
 
         for t in input_data:
             # XXX: Don't know why, but it's unreferenced twice
             # To avoid unwanted free, fix ref_count
             if t._wrapped_object.ref_count <= 0:
                 t._wrapped_object.ref_count = 1
+            # Restore child_count
             bindings.tensor_unref_child(t._wrapped_object)
 
-        return result
+        if aggregate:
+            return statistics.mean(results)
+        else:
+            return results
 
     def __repr__(self):
         name = self.__class__.__name__

--- a/pyconnx/connx/__init__.py
+++ b/pyconnx/connx/__init__.py
@@ -1,4 +1,5 @@
 import ctypes
+import gc
 import math
 import statistics
 import struct
@@ -193,6 +194,8 @@ class Model(Wrapper):
         results = []
 
         for _ in range(repeat):
+            gc_was_enabled = gc.isenabled()
+            gc.disable()
             start = time.time()
             bindings.model_run(
                 self._wrapped_object,
@@ -201,6 +204,8 @@ class Model(Wrapper):
                 ctypes.byref(output_count),
                 outputs)
             end = time.time()
+            if gc_was_enabled:
+                gc.enable()
             results.append(end - start)
             # [Tensor(outputs[i].contents) for i in range(output_count.value)]
 

--- a/pyconnx/connx/bindings.py
+++ b/pyconnx/connx/bindings.py
@@ -1,4 +1,5 @@
 import os
+
 from ctypes import (
     addressof,
     c_char_p,
@@ -30,7 +31,10 @@ class ConnxTensor(Structure):
     } connx_Tensor;
     """
     # Because it contains self pointer, pass here and monkey patch below
-    pass
+
+    def __del__(self):
+        if hasattr(self, 'allocated'):
+            tensor_unref(self)
 
 
 ConnxTensor._fields_ = [

--- a/pyconnx/connx/bindings.py
+++ b/pyconnx/connx/bindings.py
@@ -145,6 +145,10 @@ model_destroy.restype = c_int32
 hal_set_model = libconnx.hal_set_model
 hal_set_model.argtypes = [c_char_p]
 
+tensor_ref = libconnx.connx_Tensor_ref
+tensor_ref.argtypes = [POINTER(ConnxTensor)]
+tensor_ref.restype = None
+
 tensor_unref = libconnx.connx_Tensor_unref
 tensor_unref.argtypes = [POINTER(ConnxTensor)]
 tensor_unref.restype = c_int32

--- a/pyconnx/connx/bindings.py
+++ b/pyconnx/connx/bindings.py
@@ -6,7 +6,10 @@ from ctypes import (
     c_long,
     c_uint32,
     c_void_p,
-    CDLL, POINTER, Structure)
+    CDLL,
+    POINTER,
+    pointer,
+    Structure)
 
 
 libconnx = CDLL(os.path.join(os.path.dirname(__file__), 'libconnx.so'))
@@ -145,13 +148,33 @@ model_destroy.restype = c_int32
 hal_set_model = libconnx.hal_set_model
 hal_set_model.argtypes = [c_char_p]
 
-tensor_ref = libconnx.connx_Tensor_ref
-tensor_ref.argtypes = [POINTER(ConnxTensor)]
-tensor_ref.restype = None
+libconnx.connx_Tensor_ref.argtypes = [POINTER(ConnxTensor)]
+libconnx.connx_Tensor_ref.restype = None
 
-tensor_unref = libconnx.connx_Tensor_unref
-tensor_unref.argtypes = [POINTER(ConnxTensor)]
-tensor_unref.restype = c_int32
+libconnx.connx_Tensor_unref.argtypes = [POINTER(ConnxTensor)]
+libconnx.connx_Tensor_unref.restype = c_int32
+
+libconnx.connx_Tensor_ref_child.argtypes = [POINTER(ConnxTensor)]
+libconnx.connx_Tensor_ref_child.restype = None
+libconnx.connx_Tensor_unref_child.argtypes = [POINTER(ConnxTensor)]
+libconnx.connx_Tensor_unref_child.restype = c_int32
+
+
+def tensor_ref(tensor: ConnxTensor):
+    return libconnx.connx_Tensor_ref(pointer(tensor))
+
+
+def tensor_unref(tensor: ConnxTensor):
+    return libconnx.connx_Tensor_unref(pointer(tensor))
+
+
+def tensor_ref_child(tensor: ConnxTensor):
+    return libconnx.connx_Tensor_ref_child(pointer(tensor))
+
+
+def tensor_unref_child(tensor: ConnxTensor):
+    return libconnx.connx_Tensor_unref_child(pointer(tensor))
+
 
 libconnx.connx_Tensor_alloc.argtypes = [c_uint32, c_int32, POINTER(c_int32)]
 libconnx.connx_Tensor_alloc.restype = POINTER(ConnxTensor)


### PR DESCRIPTION
* Don't use clone on `Model.run`. use `ref_count` and send directly
  * Also use `child_count` to run model repeatedly on `Model.benchmark`
  * Exclude unreference time on `Model.benchmark`
* Make `Tensor.clone` faster
* Fix memory leak. call unref on `__del__`, But use a single flag to avoid double free
* Disable GC while benchmark to measure steady time

Result: (nanoseconds for total 10_000 round)
| test_name | connx(before) | connx(after) | tflite |
|:--:|--:|--:|--:|
test_add | 2,393,216,333 | 18,881,798 | 14,430,406
test_add_bcast | 2,471,384,676 | 27,010,202 | 14,642,340
test_add_uint8 | 2,359,203,716 | 18,350,124 | Missing
