### PR TITLE
[CI] Restrict python-protobuf package version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
           [[ "$ONNX_VERSION" = "latest" ]] && ONNX_VERSION='' || ONNX_VERSION="~=$ONNX_VERSION"
           pip3 install poetry
           poetry remove connx onnx
-          poetry add "onnx$ONNX_VERSION" "../[numpy]"
+          poetry add "onnx$ONNX_VERSION" "../[numpy]" "protobuf^3.20.0"
           poetry install --no-interaction --no-ansi
       - name: Run pytest for onnx test cases
         env:


### PR DESCRIPTION
Reason:
```
E   TypeError: Descriptors cannot not be created directly.
E   If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
E   If you cannot immediately regenerate your protos, some other possible workarounds are:
E    1. Downgrade the protobuf package to 3.20.x or lower.
E    2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
```