### PR TITLE
Check return value on model init

### DIFF
--- a/pyconnx/connx/__init__.py
+++ b/pyconnx/connx/__init__.py
@@ -81,7 +81,7 @@ class Tensor(Wrapper):
             nparray.shape
         ))
         data = nparray.tostring()
-        assert(len(data) == tensor.size)
+        assert len(data) == tensor.size
 
         ctypes.memmove(tensor.buffer, data, len(data))
 
@@ -101,7 +101,7 @@ class Tensor(Wrapper):
             data = data[size:]
 
         tensor = Tensor(bindings.alloc_tensor(dtype, shape))
-        assert(len(data) == tensor.size)
+        assert len(data) == tensor.size
         ctypes.memmove(tensor._wrapped_object.buffer, data, len(data))
 
         return tensor

--- a/pyconnx/connx/__init__.py
+++ b/pyconnx/connx/__init__.py
@@ -148,8 +148,12 @@ class Model(Wrapper):
         super().__init__()
         self.model_path = model_path
         with s_model_lock:
-            bindings.hal_set_model(model_path.encode())
-            bindings.model_init(self._wrapped_object)
+            res = bindings.hal_set_model(model_path.encode())
+            if res != 0:
+                raise RuntimeError(f'Failed to set model: {model_path}')
+            res = bindings.model_init(self._wrapped_object)
+            if res != 0:
+                raise RuntimeError(f'Failed to initialize model: {model_path}')
 
     def run(self, input_data: List[Tensor]) -> List[Tensor]:
         input_count = len(input_data)

--- a/pyconnx/connx/bindings.py
+++ b/pyconnx/connx/bindings.py
@@ -144,6 +144,7 @@ class ConnxModel(Structure):
 
 model_init = libconnx.connx_Model_init
 model_init.argtypes = [POINTER(ConnxModel)]
+model_init.restype = c_int32
 
 model_destroy = libconnx.connx_Model_destroy
 model_destroy.argtypes = [POINTER(ConnxModel)]
@@ -151,6 +152,7 @@ model_destroy.restype = c_int32
 
 hal_set_model = libconnx.hal_set_model
 hal_set_model.argtypes = [c_char_p]
+hal_set_model.restype = c_int32
 
 libconnx.connx_Tensor_ref.argtypes = [POINTER(ConnxTensor)]
 libconnx.connx_Tensor_ref.restype = None

--- a/pyconnx/test.py
+++ b/pyconnx/test.py
@@ -10,5 +10,5 @@ reference_data = load_data('examples/mnist/test_data_set_0/output_0.data')
 reference_nparray = reference_data.to_nparray()
 inrefence_nparray = inference_data.to_nparray()
 
-assert(reference_nparray.shape == inrefence_nparray.shape)
-assert(numpy.allclose(reference_nparray, inrefence_nparray))
+assert reference_nparray.shape == inrefence_nparray.shape
+assert numpy.allclose(reference_nparray, inrefence_nparray)


### PR DESCRIPTION
This prevents segmentation fault when trying to use unsupported operator.